### PR TITLE
Decrypt api key before using

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -268,8 +268,8 @@ class Data extends AbstractHelper
     public function getSecret()
     {
         return $this->_scopeConfig->getValue(SELF::API_SECRET_PATH, SELF::STORES_SCOPE) ?
-            $this->_scopeConfig->getValue(SELF::API_SECRET_PATH, SELF::STORES_SCOPE) :
-            $this->_scopeConfig->getValue(SELF::API_SECRET_PATH, SELF::WEBSITES_SCOPE);
+            $this->_enc->decrypt( $this->_scopeConfig->getValue(SELF::API_SECRET_PATH, SELF::STORES_SCOPE)  ):
+            $this->_enc->decript( $this->_scopeConfig->getValue(SELF::API_SECRET_PATH, SELF::WEBSITES_SCOPE) );
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "reach/reachpayment",
   "description": "",
   "type": "magento2-module",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "authors": [
       {
         "name": "Reach",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Reach_Payment" setup_version="1.2.0">
+    <module name="Reach_Payment" setup_version="1.3.0">
     	<sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
For security, Magento stores the Reach API key encrypted in the database.

Due to a bug, the module was attempting to process payment using the encrypted API key. This code fixes that bug so that the key is unencrypted temporarily before attempting to process payment with Reach.