### PR TITLE
Fix ClearanceMode to have a no selection option

### DIFF
--- a/Model/Config/Source/ClearanceMode.php
+++ b/Model/Config/Source/ClearanceMode.php
@@ -15,7 +15,7 @@ class ClearanceMode implements \Magento\Framework\Option\ArrayInterface
         return [
             ['value' => 'COURIER', 'label' => __('Courier')],
             ['value' => 'POST', 'label' => __('Post')],
-            ['value' => 'BLANK', 'label' => __('Blank')]
+            ['value' => '', 'label' => __('No Selection')]
         ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "reach/reachpayment",
   "description": "",
   "type": "magento2-module",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "authors": [
       {
         "name": "Reach",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Reach_Payment" setup_version="2.3.2">
+    <module name="Reach_Payment" setup_version="2.3.3">
     	<sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
I have to put a label of some sort into the drop-down, so I went with 'No Selection'.

If both the value and label are blank, then the UX for the drop down only gives the other two values as options.

This label can be changed if the team wants a different label.