### PR TITLE
[MAG-70] Reducing redundant calls to DHL Duty API

### DIFF
--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -134,24 +134,21 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         $this->_logger->debug($apply);
         $quote = $this->checkoutSession->getQuote();
 
+        $this->response->setIsOptional($this->getIsOptional($address->getCountryId()));
+        $this->response->setSuccess(true);
+        $this->response->setDuty($this->checkoutSession->getReachDuty()); //the DT checkbox and label
+        // should still appear if this amount is more than 0 (irrespective of whether the user chose to apply it or not on
+        // computation of total landed cost/billing)
+
         if ($apply || !$this->getIsOptional($address->getCountryId())) {
+
            $quote->setReachDuty($this->checkoutSession->getReachDuty());
-           $this->response->setIsOptional($this->getIsOptional($address->getCountryId()));
-           $this->response->setSuccess(true);
-           $this->response->setDuty($this->checkoutSession->getRechDuty());
-           $this->_logger->debug('In handleTaxApplicability method --- apply is true');
         }
         else {
-           $this->response->setIsOptional($this->getIsOptional($address->getCountryId()));
-           $this->response->setSuccess(true);
-           //as apply duty and tax(DT) is not selected duty and tax would not be used in total pricing
+
+           //as apply duty and tax(DT) is not selected; duty and tax would not be used in total pricing
            //so setting all relevant quote values to zero
-           //$quote->setDuty(0) ;
            $quote->setReachDuty(0) ;
-           $this->response->setDuty($this->checkoutSession->getReachDuty()); //the DT checkbox and label  should still appear
-           //if this amount is more than 0 even though the user did not choose to apply it on
-           //computation of total landed cost/billing
-           $this->_logger->debug('In handleTaxApplicability method --- apply is false');
         }
 
         $quote->save();//this is needed so that different aspects related to a quote are available on other pages.

--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -125,7 +125,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
      */
     public function handleTaxApplicability($address, $apply)
     {
-
         $this->_logger->debug('In handleTaxApplicability method');
         $this->_logger->debug($this->checkoutSession->getReachDuty());
         $this->_logger->debug($address->getCountryId());
@@ -134,8 +133,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         $this->_logger->debug($this->checkoutSession->getPrevRegion());
         $this->_logger->debug($apply);
         $quote = $this->checkoutSession->getQuote();
+
         if ($apply || !$this->getIsOptional($address->getCountryId())) {
-           //$quote->setDuty($this->checkoutSession->getDuty());
            $quote->setReachDuty($this->checkoutSession->getReachDuty());
            $this->response->setIsOptional($this->getIsOptional($address->getCountryId()));
            $this->response->setSuccess(true);
@@ -153,8 +152,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
            //if this amount is more than 0 even though the user did not choose to apply it on
            //computation of total landed cost/billing
            $this->_logger->debug('In handleTaxApplicability method --- apply is false');
-
         }
+
         $quote->save();//this is needed so that different aspects related to a quote are available on other pages.
         //More specifically saving quote in database is needed as apparently Magento session scopes are not application
         // wide but code area specific (?)
@@ -215,7 +214,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
     public function handleCaseWhereDutyIsAlreadyRetrieved($apply, $quote, $address)
     {
         if ($apply) {//user indicated that (s)he wants to apply duty and tax during calculation of billing
-
             $quote->setReachDuty($this->checkoutSession->getReachDuty());
             $this->response->setDuty($this->checkoutSession->getReachDuty());
             $this->handleTaxApplicability($address, $apply);
@@ -226,7 +224,7 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
             $quote->setDhlBreakdown($this->checkoutSession->getDhlBreakdown());
             $this->_logger->debug($quote->getReachDuty());
         }
-        else {////user indicated that (s)he does not  want to apply duty and tax during calculation of billing
+        else {//user indicated that (s)he does not  want to apply duty and tax during calculation of billing
             $quote->setReachDuty(0);
             //should we reset DhlQuoteId and DhlBreakdown too so as not to break any reporting?
             //I am assuming that we do
@@ -237,7 +235,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         }
 
         $quote->save();
-
         $this->response->setDuty($this->checkoutSession->getReachDuty());
     }
 
@@ -250,7 +247,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
      */
     public function fillOutQuoteAndSessionUsingFeeReturned($duty, $address, $apply, $response)
     {
-
         //dealing with whether duty and tax related checkbox is selected or not
         //or whether applying duty is a must for that country or not (a setting in magento admin
         //panel)
@@ -276,11 +272,10 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
             $quote->setDhlBreakdown(json_encode($response['feeTotals']));
             $this->checkoutSession->setDhlBreakdown($quote->getDhlBreakdown());
             $this->checkoutSession->setApply(true); //checkbox selection /corresponding passed value
-            // implies that duty should be applied
+            //implies that duty should be applied
             $this->_logger->debug('Apply block immediately after DHL call');
-
         } else {
-            //checkbox selection or paramter passed indicates that duty should not be applied
+            //checkbox selection or parameter passed indicates that duty should not be applied
             $quote->setBaseReachDuty(0);
             $quote->setReachDuty(0);
             $this->checkoutSession->setBaseReachDuty(0);
@@ -291,8 +286,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
             $this->checkoutSession->setDhlBreakdown('');
             $this->checkoutSession->setApply(false);
             $this->_logger->debug('Do not Apply block immediately after DHL call');
-
         }
+
         $quote->save();
         $this->response->setSuccess(true);
         $this->response->setDuty($duty_adjusted);
@@ -307,6 +302,7 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
     {
         $this->response->setSuccess(false);
         $this->response->setDuty(0);
+
         if (isset($response['message'])) { //error message from DHL duty and tax api call?
             //if yes then do we want to call the API again?
             //Assuming we do; we are resetting previous country and region value so that we can reenter the blcok to make
@@ -331,7 +327,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
     public function callDHLDutyTaxApi($cartId, $address, $shippingCharge, $duty, $apply, $quote)
     {
         $accessToken = $this->getDhlAccessToken();
-
 
         //Right moment to make a DHL api call for getting 'Duty and Tax' value
         if ($accessToken && $accessToken != '') {
@@ -384,7 +379,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         // when state is irrelevant?
         //The added verbose debug logging statements could be turned off by executing
         //bin/magento setup:config:set --enable-debug-logging=false
-        //
+
+
         //this can go somewhere else more appropriate
         $special_countries = array('CA','BR');
 
@@ -392,7 +388,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
             $quote = $this->getQuoteById($cartId);
             $quote->collectTotals();
             $duty=0.00;
-
             $this->_logger->debug('Entered DT routine');
 
             if (!$this->allowDuty($address->getCountryId())
@@ -427,27 +422,20 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
                         || !$address->getRegionCode()  //this check is redundant here
                     ) {
                         $this->handleCaseWithCountryAndStateSpecified($address, $apply);
-
                         return $this->response;
                     }
-
                 }
                 else {//country selection did not change and we are assuming (as we do not have extra info handy)
                     //for these countries D&T does not changes with change in state (double check with the business)
                     $quote = $this->checkoutSession->getQuote();
                     $this->response->setSuccess(true);
                     $this->_logger->debug('country selection did not change and not a special country');
-
                     $this->handleCaseWhereDutyIsAlreadyRetrieved($apply, $quote, $address);
-
                     return $this->response;
                 }
-
-
             }
             //trying to get Duty value by calling DHL Duty API
             $this->callDHLDutyTaxApi($cartId, $address, $shippingCharge, $duty, $apply, $quote);
-
         } catch (\Exception $e) {
             $this->response->setSuccess(false);
             $this->response->setErrorMessage(
@@ -514,9 +502,9 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
     {
         if ($this->reachHelper->getDhlAllowSpecific()) {
             $allowed = $this->reachHelper->getDhlAllowedCountries();
-
             $countries = explode(',', $allowed);
             $this->_logger->debug('$allowed ::'.$allowed);
+
             if (!in_array($countryId, $countries)) {
                 return false;
             }

--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -151,9 +151,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
            $quote->setReachDuty(0) ;
         }
 
-        $quote->save();//this is needed so that different aspects related to a quote are available on other pages.
-        //More specifically saving quote in database is needed as apparently Magento session scopes are not application
-        // wide but code area specific (?)
+        $quote->save();//this is needed so that different aspects related to a quote are available on other
+        // pages/propagate to other pages (without changing existing code on those pages).
     }
 
 
@@ -357,27 +356,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
       */
     public function getDutyandTax($cartId, $shippingCharge, $shippingMethodCode, $shippingCarrierCode, $address, $apply = false)
     {
-        //Some comments/concerns which may be relevant to the reviewer
-        //using this style https://pear.php.net/manual/en/rfc.cs-enhancements.splitlongstatements.php
-        //to split long conditions into multiline
-
-        //this code is done on limited time
-        //cleaner more concise logic is possible provided more time was available to write the code
-        //significant amount of time was passed tracking changes due to event and side effect of blocking multiple DHL
-        // api call
-        //and limited time spent on bringing a fix of average quality (under pressure)
-        //also are we supposed to enforce  80 characters line limit or such
-
-        //what is not tested: multiple cart items in same order each delivered to different places with differing duties
-        //when someone comeback after sometime in the same session
-        //did not tested as a logged in user
-        //After latest round of code reorganization did not try putting order for a country (with applicable duty)
-        //finish checkout and then in the same session put another order for the same country . Is another DHL call made
-        // when state is irrelevant?
-        //The added verbose debug logging statements could be turned off by executing
-        //bin/magento setup:config:set --enable-debug-logging=false
-
-
         //this can go somewhere else more appropriate
         $special_countries = array('CA','BR');
 

--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -128,7 +128,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
 
         $this->_logger->debug('In handleTaxApplicability method');
         $this->_logger->debug($this->checkoutSession->getReachDuty());
-        #$apply = $this->checkoutSession->getApply();
         $this->_logger->debug($address->getCountryId());
         $this->_logger->debug($address->getRegionCode());
         $this->_logger->debug($this->checkoutSession->getPrevCountry());
@@ -146,8 +145,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         else {
            $this->response->setIsOptional($this->getIsOptional($address->getCountryId()));
            $this->response->setSuccess(true);
-           #as apply duty and tax(DT) is not selected duty and tax would not be used in total pricing
-           #so setting all relevant quote values to zero
+           //as apply duty and tax(DT) is not selected duty and tax would not be used in total pricing
+           //so setting all relevant quote values to zero
            //$quote->setDuty(0) ;
            $quote->setReachDuty(0) ;
            $this->response->setDuty($this->checkoutSession->getReachDuty()); //the DT checkbox and label  should still appear
@@ -228,7 +227,6 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
             $this->_logger->debug($quote->getReachDuty());
         }
         else {////user indicated that (s)he does not  want to apply duty and tax during calculation of billing
-            //$quote->setDuty(0) ; #$this->checkoutSession->getDuty());
             $quote->setReachDuty(0);
             //should we reset DhlQuoteId and DhlBreakdown too so as not to break any reporting?
             //I am assuming that we do
@@ -277,8 +275,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
             $quote->setDhlQuoteId($response['quoteId']);
             $quote->setDhlBreakdown(json_encode($response['feeTotals']));
             $this->checkoutSession->setDhlBreakdown($quote->getDhlBreakdown());
-            $this->checkoutSession->setApply(true); #checkbox selection /corresponding passed value
-            # implies that duty should be applied
+            $this->checkoutSession->setApply(true); //checkbox selection /corresponding passed value
+            // implies that duty should be applied
             $this->_logger->debug('Apply block immediately after DHL call');
 
         } else {

--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -367,6 +367,11 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
       */
     public function getDutyandTax($cartId, $shippingCharge, $shippingMethodCode, $shippingCarrierCode, $address, $apply = false)
     {
+        //DHL API call is not required if DHL option is not enabled from admin
+        if (!$this->reachHelper->getDhlEnabled()) {
+           return;
+        }
+
         //this can go somewhere else more appropriate
         $countries_require_state = array('CA','BR');
 

--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -139,18 +139,22 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         $this->response->setDuty($this->checkoutSession->getReachDuty()); //the DT checkbox and label
         // should still appear if this amount is more than 0 (irrespective of whether the user chose to apply it or not on
         // computation of total landed cost/billing)
+        $isDutyOptional = $this->getIsOptional($address->getCountryId());
+        $this->_logger->debug("Value of apply ".$apply);
+        $this->_logger->debug("Value of isDutyOptional ".$isDutyOptional);
 
-        if ($apply || !$this->getIsOptional($address->getCountryId())) {
-
+        if ($apply || !$isDutyOptional) {
+           $this->_logger->debug("Duty should be applied (due to user selection or the value of the 'apply' ".
+               " parameter that is passed to this function or because duty is not optional for the chosen country ".
+               "(shipment address)");
            $quote->setReachDuty($this->checkoutSession->getReachDuty());
         }
         else {
-
-           //as apply duty and tax(DT) is not selected; duty and tax would not be used in total pricing
-           //so setting all relevant quote values to zero
+            $this->_logger->debug("Duty should not be applied.");
+            //as apply duty and tax(DT) is not selected or it is optional; duty and tax would not be used in total
+            // pricing; so setting all relevant quote values to zero
            $quote->setReachDuty(0) ;
         }
-
         $quote->save();//this is needed so that different aspects related to a quote are available on other
         // pages/propagate to other pages (without changing existing code on those pages).
     }
@@ -172,7 +176,7 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         $quote->save();
     }
 
-    /** Sets appropriate response (eventually be https response) values
+    /** Sets appropriate response (as per DutyResponseInterface) values
      * when state/province is (needed for proper duty calculation
      * but) not yet specified
      * @param float $duty
@@ -182,8 +186,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
        $quote = $this->checkoutSession->getQuote();
        $this->response->setSuccess(true);
        $this->response->setDuty($duty);
-       $this->_logger->debug('Special country where state selection is neccessary before initiating DHL API call;
-                but state is not selected anyway.');
+       $this->_logger->debug('Special country where state selection is necessary before initiating DHL API call;'.
+                'but state is not selected anyway.');
     }
 
 

--- a/view/frontend/web/js/view/shipping.js
+++ b/view/frontend/web/js/view/shipping.js
@@ -124,7 +124,8 @@ define([
             this.applyDuty.subscribe(function(){
                 self.applyDutyCharges()
             });
-            if( window.checkoutConfig.reach.enabled != 0)
+            //DHL is not enabled from admin - so duty calculation is not needed
+            if (window.checkoutConfig.reach.dhl_enabled != 0)
             {
                 quote.shippingMethod.subscribe(function(){            
                     self.getDutyCharges();


### PR DESCRIPTION
This work tries to reduce redundant/extra calls to DHL duty calculation service.

In pre-existing extension code as is the following activities of probable buyer/customer in Magento store/front use to cause multiple/redundant calls (DHL duty calculation).

- Changes in digits in postal code, 

- Changes in state/division (even when it is not relevant for calculating duties for the shipping address under consideration), 

-  Validation error in user name email etc. used.

-  When apply duty & tax checkbox is selected or deselected from the checkout page

- When the 'next' button is pressed on the checkout page. 


Tried to fix the problem leveraging Magento Checkout Session as well as 'state' of DHL Quote stored in the database. A separate document will be supplied highlighting how it was tested, test cases suggestions, limitations of the current solution etc.

Committed some extraneous blank lines. Would be more than happy to remove.  