### PR TITLE
Mag 75 - More resilient method of determining local IP address

### DIFF
--- a/Model/Currency.php
+++ b/Model/Currency.php
@@ -142,6 +142,7 @@ class Currency extends \Magento\Framework\Model\AbstractModel
      */
     public function getLocalizeCurrency()
     {
+        $this->_logger->debug('------------- Currency::getLocalizeCurrency() : START ------------------');
         $rest = $this->httpRestFactory->create();
         $url = $this->reachHelper->getApiUrl();
         $url = $url.'localize?MerchantId='.$this->reachHelper->getMerchantId();
@@ -149,10 +150,21 @@ class Currency extends \Magento\Framework\Model\AbstractModel
         if (!$this->checkLocalIP($ip)) {
             $url = $url.'&ConsumerIpAddress='.$ip;
         }
+
+        $this->_logger->debug('url: ');
+        $this->_logger->debug(json_encode($url));
+
         $rest->setUrl($url);
         $response = $rest->executeGet();
+
+        $this->_logger->debug('response: ');
+        $this->_logger->debug(json_encode($response));
+
         $result = $response->getResponseData();
         
+        $this->_logger->debug('result: ');
+        $this->_logger->debug(json_encode($result));
+
         if (isset($result['Currency'])) {
             return [
                 'currency'=>$result['Currency'],
@@ -160,6 +172,7 @@ class Currency extends \Magento\Framework\Model\AbstractModel
                 'country'=>$result['Country']
             ];
         }
+        $this->_logger->debug('------------- Currency::getLocalizeCurrency() : END ------------------');
         return false;
     }
 
@@ -222,6 +235,15 @@ class Currency extends \Magento\Framework\Model\AbstractModel
      */
     protected function checkLocalIP($ip)
     {
-        return in_array($ip, ['localhost','127.0.0.1','172.19.0.1','172.25.0.7','172.25.0.1']);
+        $this->_logger->debug('------------- Currency::checkLocalIP() : START ------------------');
+        if ( ! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) )
+        {
+            // is a local ip address
+            $this->_logger->debug('Using a local IP address');
+            return true;
+        }
+        $this->_logger->debug('Using a public IP address');
+        $this->_logger->debug('------------- Currency::checkLocalIP() : END ------------------');
+        return false;
     }
 }

--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -287,6 +287,7 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         $quote = $this->checkoutSession->getQuote();
        
         if ($quote->getId()) {
+            $this->_logger->debug("----------- DutyCalculator::prepareRequest  - START ---------------");
             $request=[];
                            
             $request['pickupAccount'] = $this->reachHelper ->getDhlPickupAccount();
@@ -308,14 +309,41 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
 
                 $itemData=[];
                 $itemData['itemId']=(string)$item->getId();
+                $this->_logger->debug("itemId: ");
+                $this->_logger->debug(json_encode($itemData['itemId']));
+
+                $this->_logger->debug('SKU: ');
+                $this->_logger->debug(json_encode($item->getSku()));
+
+                $this->_logger->debug('Item Details: ');
+                $this->_logger->debug(
+                    json_encode($this->testProductDetails($item->getSku()))
+                );
+
                 $itemData['hsCode']=$this->getHsCode($item->getSku());
                 if (!$itemData['hsCode']) {
                     $itemData['hsCode']=$this->reachHelper->getDhlDefaultHsCode();
                 }
+
+                $this->_logger->debug("hsCode: ");
+                $this->_logger->debug(json_encode($itemData['hsCode']));
+
                 $itemData['skuNumber']=$item->getSku();
                 $itemData['itemValue']=['value'=>$item->getRowTotal()/$item->getQty(),'currency'=>$quote->getQuoteCurrencyCode()];
+
+                $this->_logger->debug("itemValue: ");
+                $this->_logger->debug(json_encode($itemData['itemValue']));
+
                 $itemData['itemQuantity']=['value'=>$item->getQty(),'unit'=>"PCS"];
+
+                $this->_logger->debug("itemQuantity: ");
+                $this->_logger->debug(json_encode($itemData['itemQuantity']));
+
                 $itemData['countryOfOrigin'] = $this->getCountryOfOrigin($item->getSku());
+
+                $this->_logger->debug("countryOfOrigin: ");
+                $this->_logger->debug(json_encode($itemData['countryOfOrigin']));
+
                 if (!$itemData['countryOfOrigin']) {
                     $itemData['countryOfOrigin'] = $request['senderAddress']['country'];
                 }
@@ -326,6 +354,7 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
                 }
                 $request['customsDetails'][]=$itemData;
             }
+            $this->_logger->debug("----------- DutyCalculator::prepareRequest  - END ---------------");
             return $request;
         }
     }
@@ -357,6 +386,10 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
         ;
         
         return $origin;
+    }
+
+    public function testProductDetails($sku) {
+        return $this->csvHsCodeFactory->create()->testProductDetails($sku);
     }
 
     /**

--- a/Model/Paypal.php
+++ b/Model/Paypal.php
@@ -399,8 +399,8 @@ class Paypal extends \Magento\Payment\Model\Method\AbstractMethod
         $this->_logger->debug(json_encode($this->reachPayment->testLocalizeCurrency()));
 
         $this->_logger->debug('---------------- isAvailable - END OF REQUEST----------------');
-       // return $this->reachPayment->isAvailable(self::METHOD_PAYPAL) && $this->_scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $this->storeManager->getStore()->getId());
-       return $this->_scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $this->storeManager->getStore()->getId());
+        return ($this->reachPayment->isAvailable(self::METHOD_PAYPAL) && 
+            $this->_scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $this->storeManager->getStore()->getId()));
     }
 
      /**

--- a/Model/Paypal.php
+++ b/Model/Paypal.php
@@ -361,12 +361,46 @@ class Paypal extends \Magento\Payment\Model\Method\AbstractMethod
      */
     public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = null)
     {
+        $this->_logger->debug('---------------- isAvailable - START OF REQUEST----------------');
+        $this->_logger->debug('PayPal Enabled: ');
+        $this->_logger->debug($this->reachHelper->getReachEnabled());
         if(!$this->reachHelper->getReachEnabled())
         {
             return false;
         } 
-       $path = 'payment/'.self::METHOD_PAYPAL . '/active';                
-       return $this->reachPayment->isAvailable(self::METHOD_PAYPAL) && $this->_scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $this->storeManager->getStore()->getId());
+        $path = 'payment/'.self::METHOD_PAYPAL . '/active';
+        $this->_logger->debug('Reach is Enabled!');
+
+        $this->_logger->debug('Path:');
+        $this->_logger->debug(json_encode($path));
+
+        $this->_logger->debug('Calc 1:');
+        $this->_logger->debug(json_encode($this->reachPayment->isAvailable(self::METHOD_PAYPAL)));
+
+        $this->_logger->debug('Calc 2:');
+        $this->_logger->debug(json_encode($this->_scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $this->storeManager->getStore()->getId())));
+
+        $this->_logger->debug('methods:');
+        $this->_logger->debug(json_encode($this->reachPayment->testMethods()));
+
+        $this->_logger->debug('testCurrencyCode:');
+        $this->_logger->debug(json_encode($this->reachPayment->testCurrencyCode()));
+
+        $this->_logger->debug('testLocalize:');
+        $this->_logger->debug(json_encode($this->reachPayment->testLocalize()));
+
+        $this->_logger->debug('testreachmethods:');
+        $this->_logger->debug(json_encode($this->reachPayment->testreachmethods()));
+
+        $this->_logger->debug('testGetLocalize:');
+        $this->_logger->debug(json_encode($this->reachPayment->testGetLocalize()));
+
+        $this->_logger->debug('testLocalizeCurrency:');
+        $this->_logger->debug(json_encode($this->reachPayment->testLocalizeCurrency()));
+
+        $this->_logger->debug('---------------- isAvailable - END OF REQUEST----------------');
+       // return $this->reachPayment->isAvailable(self::METHOD_PAYPAL) && $this->_scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $this->storeManager->getStore()->getId());
+       return $this->_scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $this->storeManager->getStore()->getId());
     }
 
      /**

--- a/Model/Reach.php
+++ b/Model/Reach.php
@@ -57,21 +57,41 @@ class Reach
         
     }
 
+    /**
+     * Returns payment methods for debugging.
+     *
+     * @return array
+     */
     public function testMethods(){
         $methods = $this->fetchPaymentMethods();
         return $methods;
     }
 
+    /**
+     * Returns current currency code from session for debugging.
+     *
+     * @return array
+     */
     public function testCurrencyCode() {
         $currencyCode = $this->checkoutSession->getQuote()->getQuoteCurrencyCode();
         return $currencyCode;
     }
 
+    /**
+     * Returns if the store is configured for localization.
+     *
+     * @return boolean
+     */
     public function testLocalize() {
         $localize = $this->getLocalize();
         return $localize;
     }
 
+    /**
+     * Returns configured Reach methods from current session for debugging.
+     *
+     * @return array
+     */
     public function testReachMethods() {
         return $this->checkoutSession->getReachMethods();
     }
@@ -149,10 +169,20 @@ class Reach
         return $methods;
     }
 
+    /**
+     * Test if core session is configured for localization.
+     *
+     * @return array
+     */
     public function testGetLocalize() {
         return $this->_coresession->getLocalize();
     }
 
+    /**
+     * Test if currency model is configured for localization.
+     *
+     * @return array
+     */
     public function testLocalizeCurrency() {
         $localize = $this->currencyModel->getLocalizeCurrency();
         return $localize;

--- a/Model/Reach.php
+++ b/Model/Reach.php
@@ -47,7 +47,7 @@ class Reach
         \Reach\Payment\Model\Currency $currencyModel,
         \Reach\Payment\Helper\Data $helper,
         \Magento\Checkout\Model\Session $checkoutSession,
-        \Reach\Payment\Model\Api\HttpRestFactory $httpRestFactory,
+        \Reach\Payment\Model\Api\HttpRestFactory $httpRestFactory
     ) {
         $this->_coresession     = $session;
         $this->currencyModel    = $currencyModel;
@@ -88,7 +88,7 @@ class Reach
             if (array_key_exists('Card', $methods) && $method == \Reach\Payment\Model\Cc::METHOD_CC) {
                 $available = true;
             }
-            if (array_key_exists('Online', $methods) && $method == 'payment/reach_paypal/active') {
+            if (array_key_exists('Online', $methods) && $method == \Reach\Payment\Model\Paypal::METHOD_PAYPAL) {
                 if (array_key_exists('Online', $methods)) {
                     foreach ($methods['Online'] as $onmethod) {
                         if ($onmethod['Id'] == 'PAYPAL') {

--- a/Model/Reach.php
+++ b/Model/Reach.php
@@ -33,8 +33,6 @@ class Reach
      */
     protected $httpRestFactory;
 
-    protected $_logger;
-
     /**
      * Constructor
      *
@@ -43,7 +41,6 @@ class Reach
      * @param \Reach\Payment\Helper\Data $hlper
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Reach\Payment\Model\Api\HttpRestFactory $httpRestFactory
-     * @param \Magento\Payment\Model\Method\Logger $logger
      */
     public function __construct(
         \Magento\Framework\Session\SessionManagerInterface $session,
@@ -51,7 +48,6 @@ class Reach
         \Reach\Payment\Helper\Data $helper,
         \Magento\Checkout\Model\Session $checkoutSession,
         \Reach\Payment\Model\Api\HttpRestFactory $httpRestFactory,
-        \Magento\Payment\Model\Method\Logger $logger
     ) {
         $this->_coresession     = $session;
         $this->currencyModel    = $currencyModel;

--- a/Model/Reach.php
+++ b/Model/Reach.php
@@ -109,11 +109,9 @@ class Reach
                 $available = true;
             }
             if (array_key_exists('Online', $methods) && $method == \Reach\Payment\Model\Paypal::METHOD_PAYPAL) {
-                if (array_key_exists('Online', $methods)) {
-                    foreach ($methods['Online'] as $onmethod) {
-                        if ($onmethod['Id'] == 'PAYPAL') {
-                            $available = true;
-                        }
+                foreach ($methods['Online'] as $onmethod) {
+                    if ($onmethod['Id'] == 'PAYPAL') {
+                        $available = true;
                     }
                 }
             }

--- a/Model/Reach.php
+++ b/Model/Reach.php
@@ -129,7 +129,7 @@ class Reach
         $localize = $this->getLocalize();
         $currencyCode = $this->checkoutSession->getQuote()->getQuoteCurrencyCode();
         if (!$localize || !isset($localize['country'])) {
-            return ['no localization'];
+            return [];
         }
 
         $sessionMethods=[];

--- a/Model/ResourceModel/CsvHsCode.php
+++ b/Model/ResourceModel/CsvHsCode.php
@@ -27,16 +27,28 @@ class CsvHsCode extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $this->_init('reach_hs_code', 'id');
     }
 
+    public function testProductDetails($sku) {
+        $connection = $this->getConnection();
+        $select = $connection->select()->from($this->getMainTable());
+        $select->where('sku = ?', $sku);
+        $result = $connection->fetchRow($select);
+        return $result;
+    }
+
     public function getHsCode($sku)
     {
         $connection = $this->getConnection();
         $select = $connection->select()->from($this->getMainTable());
         $select->where('sku = ?', $sku);
         $result = $connection->fetchRow($select);
-        if (count($result) && isset($result['hs_code'])) {
-            return $result['hs_code'];
+
+        if ($result) {
+            if (count($result) && isset($result['hs_code'])) {
+                return $result['hs_code'];
+            }
+        } else {
+            return null;
         }
-        return null;
     }
 
     public function getCountryOfOrigin($sku)
@@ -45,9 +57,12 @@ class CsvHsCode extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $select = $connection->select()->from($this->getMainTable());
         $select->where('sku = ?', $sku);
         $result = $connection->fetchRow($select);
-        if (count($result) && isset($result['country_of_origin'])) {
-            return $result['country_of_origin'];
+        if ($result) {
+            if (count($result) && isset($result['country_of_origin'])) {
+                return $result['country_of_origin'];
+            }
+        } else {
+            return null;
         }
-        return null;
     }
 }


### PR DESCRIPTION
This ticket only affects developers running the site locally on their computers.

During the checkout process, the currency lookup API call needs to know if the website is being hosted on a local network (i.e. during development) or on a publicly available IP address.

When testing locally without this code fix, you will sometimes not see any payment options other than Check/Money Order. This fix allows developers to run the code locally and see all the available payment methods.

This ticket replaces the checkLocalIP function in Currency.php with a more resilient method to better handle different use cases. This ticket also adds more debug console logging to help during future debugging.