### PR TITLE
[MAG-81] Generate a new DHL api call when there is a change in cart.

### DIFF
--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -412,7 +412,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
                 //if chosen country is one of the special countries where state is needed
                 //but state is either not specified
                 if (in_array($address->getCountryId(), $countries_require_state, true)) {
-                    if (($this->checkoutSession->getPrevRegion() == $address->getRegionCode())
+                    if ((($this->checkoutSession->getPrevRegion() == $address->getRegionCode())
+                        &&  $this->checkoutSession->getPrevRegion() !='')
                         || !$address->getRegionCode()  //this check is redundant here
                     ) {
                         $this->handleCaseWithCountryAndStateSpecified($address, $apply);

--- a/Model/ResourceModel/CsvHsCode.php
+++ b/Model/ResourceModel/CsvHsCode.php
@@ -33,7 +33,7 @@ class CsvHsCode extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $select = $connection->select()->from($this->getMainTable());
         $select->where('sku = ?', $sku);
         $result = $connection->fetchRow($select);
-        if (count($result) && isset($result['hs_code'])) {
+        if ($result && count($result) && isset($result['hs_code'])) {
             return $result['hs_code'];
         }
         return null;
@@ -45,7 +45,7 @@ class CsvHsCode extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $select = $connection->select()->from($this->getMainTable());
         $select->where('sku = ?', $sku);
         $result = $connection->fetchRow($select);
-        if (count($result) && isset($result['country_of_origin'])) {
+        if ($result && count($result) && isset($result['country_of_origin'])) {
             return $result['country_of_origin'];
         }
         return null;

--- a/Observer/CartChangedObserver.php
+++ b/Observer/CartChangedObserver.php
@@ -1,0 +1,79 @@
+<?php
+namespace Reach\Payment\Observer;
+
+use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\Event\ObserverInterface;
+
+class CartChangedObserver implements ObserverInterface
+{
+
+    /**
+     * @var eventManager
+     */
+    protected $_eventManager;
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $_objectManager;
+
+    /**
+     * @var Session
+     */
+    protected $_checkoutSession;
+
+
+    /**
+     * @param \Magento\Framework\Event\Manager            $eventManager
+     * @param \Magento\Framework\ObjectManagerInterface   $objectManager
+     * @param \Magento\Checkout\Model\Session             $checkoutSession
+     */
+    public function __construct(
+        \Magento\Framework\Event\Manager $eventManager,
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        \Magento\Checkout\Model\Session             $checkoutSession
+    ) {
+        $this->_eventManager = $eventManager;
+        $this->_objectManager = $objectManager;
+        $this->_checkoutSession = $checkoutSession;
+    }
+
+    /**
+     * Set payment fee to order
+     *
+     * @param EventObserver $observer
+     * @return $this
+     */
+    //checkout_cart_save_after
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        try {
+            $this->_checkoutSession->setPrevCountry('');
+            $this->_checkoutSession->setPrevRegion('');
+        } catch (\Exception $e) {
+            $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/oc-save-error.log');
+            $logger = new \Zend\Log\Logger();
+            $logger->addWriter($writer);
+            $logger->info($e->getMessage());
+        }
+        return $this;
+    }
+
+
+    /**
+     * validate response
+     *
+     * @param array $response
+     * @param string $nonce
+     * @return boolean
+     */
+    /*
+    protected function validateResponse($response, $nonce)
+    {
+        $nonce = str_replace(' ', '+', $nonce);
+        $key = $this->reachHelper->getSecret();
+        $signature =  base64_encode(hash_hmac('sha256', $response, $key, true));
+        return $signature == $nonce;
+    }*/
+
+}

--- a/Observer/CartChangedObserver.php
+++ b/Observer/CartChangedObserver.php
@@ -39,15 +39,17 @@ class CartChangedObserver implements ObserverInterface
     }
 
     /**
-     * Set payment fee to order
-     *
+     * handles 'checkout_cart_save_before' core Magento event
+     * basically cleans up the system state (session not database) necessary for triggering a new DHL api call when
+     * 1. there is change in the cart and
+     * 2. checkout is attempted.
      * @param EventObserver $observer
      * @return $this
      */
-    //checkout_cart_save_after
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
         try {
+            //clearing previously saved country and state information in the checkout session
             $this->_checkoutSession->setPrevCountry('');
             $this->_checkoutSession->setPrevRegion('');
         } catch (\Exception $e) {
@@ -58,22 +60,4 @@ class CartChangedObserver implements ObserverInterface
         }
         return $this;
     }
-
-
-    /**
-     * validate response
-     *
-     * @param array $response
-     * @param string $nonce
-     * @return boolean
-     */
-    /*
-    protected function validateResponse($response, $nonce)
-    {
-        $nonce = str_replace(' ', '+', $nonce);
-        $key = $this->reachHelper->getSecret();
-        $signature =  base64_encode(hash_hmac('sha256', $response, $key, true));
-        return $signature == $nonce;
-    }*/
-
 }

--- a/Observer/CartChangedObserver.php
+++ b/Observer/CartChangedObserver.php
@@ -39,7 +39,7 @@ class CartChangedObserver implements ObserverInterface
     }
 
     /**
-     * handles 'checkout_cart_save_before' core Magento event
+     * handles 'checkout_cart_save_after' core Magento event
      * basically cleans up the system state (session not database) necessary for triggering a new DHL api call when
      * 1. there is change in the cart and
      * 2. checkout is attempted.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "reach/reachpayment",
   "description": "",
   "type": "magento2-module",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "authors": [
       {
         "name": "Reach",

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -2,6 +2,9 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="checkout_cart_save_before" >
+        <observer name="reach_checkout_cart_save_before_observer" instance="Reach\Payment\Observer\CartChangedObserver" />
+    </event>
     <event name="sales_model_service_quote_submit_before">
         <observer name="reachduty" instance="Reach\Payment\Observer\AddDutyToOrderObserver" />
     </event>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -2,8 +2,8 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="checkout_cart_save_before" >
-        <observer name="reach_checkout_cart_save_before_observer" instance="Reach\Payment\Observer\CartChangedObserver" />
+    <event name="checkout_cart_save_after" >
+        <observer name="reach_checkout_cart_save_after_observer" instance="Reach\Payment\Observer\CartChangedObserver" />
     </event>
     <event name="sales_model_service_quote_submit_before">
         <observer name="reachduty" instance="Reach\Payment\Observer\AddDutyToOrderObserver" />

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Reach_Payment" setup_version="2.3.4">
+    <module name="Reach_Payment" setup_version="2.3.5">
     	<sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
* Added new check so that state and country would not be considered as
unchanged when all of those are blanks.
* Added extra check while retrieving HSCode and country related information
from the database so that there is no error if nothing is retrieved from
the database.
* Added an observer/listener/handler that prepares the extension to generate
a new DHL call when there is a change in the shopping cart (due to adding or
 removing products).
* Associated cart change and the piece of code (handler) that does necessary
 cleanup needed for the system to trigger a new DHL api call.

* Have to add proper version based on when it goes out. 