### PR TITLE
[MAG-79] Fixing Issues With Default Configuration

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -19,8 +19,8 @@ class Data extends AbstractHelper
 
     const DHL_API_URL = 'https://api.dhlecommerce.com/';
     const DHL_SANDBOX_API_URL = 'https://api-sandbox.dhlecommerce.com/';
-    const DHL_ENABLE = 'payment/reach_payment/reach_dhl/enable';
-    const DHL_DUTY_LABEL = 'payment/reach_payment/reach_dhl/duty_label';
+    const DHL_ENABLE = 'reach/dhl/enable';
+    const DHL_DUTY_LABEL = 'reach/dhl/duty_label';
     const DHL_DUTY_ALLOW_SPECIFIC = 'reach/dhl/allowspecific';
     const DHL_DUTY_ALLOW_SPECIFIC_COUNTRY = 'reach/dhl/specificcountry';
     const DHL_DUTY_OPTIONAL_SPECIFIC = 'reach/dhl/optional_allowspecific';
@@ -42,11 +42,11 @@ class Data extends AbstractHelper
 
     const CONFIG_CC_OPEN_ONCTRACT = 'payment/reach_cc/allow_open_contract';
 
-    const DHL_PREF_TARIFFS          = "payment/reach_payment/reach_dhl/pref_tariffs";
-    const DHL_PRICING_STRATEGY_PATH = "payment/reach_payment/reach_dhl/pricing_strategy";
-    const DHL_CLEARANCE_MODE_PATH   = "payment/reach_payment/reach_dhl/clearance_mode";
-    const DHL_END_USE_PATH          = "payment/reach_payment/reach_dhl/end_use";
-    const DHL_TRANSPORT_MODE_PATH   = "payment/reach_payment/reach_dhl/transport_mode";
+    const DHL_PREF_TARIFFS          = "reach/dhl/pref_tariffs";
+    const DHL_PRICING_STRATEGY_PATH = "reach/dhl/pricing_strategy";
+    const DHL_CLEARANCE_MODE_PATH   = "reach/dhl/clearance_mode";
+    const DHL_END_USE_PATH          = "reach/dhl/end_use";
+    const DHL_TRANSPORT_MODE_PATH   = "reach/dhl/transport_mode";
     const SANDBOX_MODE = 1;
 
     /**
@@ -109,7 +109,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Get if qualifies for preferential tariffs DHL_PREF_TARIFFS
+     * Reading whether item/product qualifies for preferential tariffs
      *
      */
     public function getPrefTariffs() {
@@ -159,8 +159,8 @@ class Data extends AbstractHelper
     public function getReachEnabled()
     {
         return $this->getConfigValue(self::CONFIG_REACH_ENABLED);
-    }    
-    
+    }
+
     /**
      * getCoreSession
      * @return object
@@ -172,7 +172,7 @@ class Data extends AbstractHelper
         return $core_session;
     }
 
-    
+
     /**
      * getCheckoutSession
      * @return object
@@ -429,7 +429,7 @@ class Data extends AbstractHelper
     {
         return $this->getConfigValue(self::DHL_DUTY_LABEL);
     }
-    
+
     /**
      * Get DHL allowed specific
      *

--- a/Model/Config/Source/PrefTariffs.php
+++ b/Model/Config/Source/PrefTariffs.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Reach\Payment\Model\Config\Source;
+
+class PrefTariffs implements \Magento\Framework\Option\ArrayInterface
+{
+
+    /**
+     * Return array of options as value-label pairs, eg. value => label
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 1, 'label' => __('True')],
+            ['value' => 0, 'label' => __('False')]
+        ];
+    }
+}

--- a/Model/Config/Source/PricingStrategy.php
+++ b/Model/Config/Source/PricingStrategy.php
@@ -13,8 +13,8 @@ class PricingStrategy implements \Magento\Framework\Option\ArrayInterface
     public function toOptionArray()
     {
         return [
-            ['value' => 'MINIMUM', 'label' => __('MINIMUM')],
             ['value' => 'MAXIMUM', 'label' => __('MAXIMUM')],
+            ['value' => 'MINIMUM', 'label' => __('MINIMUM')],
             ['value' => 'AVERAGE', 'label' => __('AVERAGE')],
             ['value' => 'EXACT',   'label' => __('EXACT')],
         ];

--- a/Model/DutyCalculator.php
+++ b/Model/DutyCalculator.php
@@ -441,7 +441,7 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
 
         return $this->response;
     }
-    
+
     /**
      * Get repository
      *
@@ -532,10 +532,9 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
     protected function prepareRequest($freightCharge, $shippingAddress)
     {
         $quote = $this->checkoutSession->getQuote();
-       
+
         if ($quote->getId()) {
             $request=[];
-                           
             $request['pickupAccount'] = $this->reachHelper ->getDhlPickupAccount();
             $request['itemSeller']= $this->reachHelper->getDhlItemSeller();
             $request['pricingStrategy']=$this->reachHelper->getPricingStrategy();
@@ -573,6 +572,8 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
                 }
                 $request['customsDetails'][]=$itemData;
             }
+
+            $this->_logger->debug(json_encode($request));
             return $request;
         }
     }
@@ -602,7 +603,7 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
             $this->storeManager->getStore()->getId()
         );
         ;
-        
+
         return $origin;
     }
 
@@ -622,7 +623,7 @@ class DutyCalculator implements \Reach\Payment\Api\DutyCalculatorInterface
     }
 
     /**
-     * Get SKU specific Country of Origin 
+     * Get SKU specific Country of Origin
      *
      * @param string $sku
      * @return string

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,7 +14,7 @@
                     <depends>
                         <field id="active">1</field>
                     </depends>
-                    <config_path>reach/global/mearchant_id</config_path>
+                    <!-- No config path as it has no default -->
                     <validate>required-entry</validate>
                 </field>
                 <field id="api_secret" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="4" translate="label" type="obscure">
@@ -23,7 +23,7 @@
                     <depends>
                         <field id="active">1</field>
                     </depends>
-                    <config_path>reach/global/api_secret</config_path>
+                    <!-- No config path as it has no default -->
                     <validate>required-entry</validate>
                 </field>
                 <field id="mode" sortOrder="5" translate="label" type="select"  showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
@@ -33,31 +33,32 @@
                         <field id="active">1</field>
                     </depends>
                     <config_path>reach/global/mode</config_path>
-                </field>             
+                </field>
                 <field id="display_currency_switch" sortOrder="7" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Currency Options</label>
                     <source_model>Reach\Payment\Model\Config\Source\Currency</source_model>
                     <depends>
                         <field id="active">1</field>
                     </depends>
-                    <config_path>reach/global/display_currency_switch</config_path>
+                    <!-- No config path as it has no default -->
                 </field>
                 <field id="allowspecific" translate="label" type="allowspecific" sortOrder="8"  showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Currency For Applicable Countries</label>                    
-                    <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>                    
+                    <label>Currency For Applicable Countries</label>
+                    <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
                     <config_path>reach/global/allowspecific</config_path>
                     <depends>
-                        <field id="display_currency_switch" separator=",">customer,reach</field>                        
+                        <field id="display_currency_switch" separator=",">customer,reach</field>
                     </depends>
+                    <!-- No config path as it has no default -->
                 </field>
                 <field id="specificcountry" translate="label" type="multiselect" sortOrder="9" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Currency For Specific Countries</label>
                     <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-                        <can_be_empty>1</can_be_empty> 
-                    <config_path>reach/global/specificcountry</config_path>
-                   <depends>
-                        <field id="display_currency_switch" separator=",">customer,reach</field>                        
+                        <can_be_empty>1</can_be_empty>
+                    <depends>
+                        <field id="display_currency_switch" separator=",">customer,reach</field>
                     </depends>
+                    <!-- No config path as it has no default -->
                 </field>
                 <group id="reach_dhl" translate="label comment" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1" >
                     <label>DHL Credentials</label>
@@ -67,15 +68,17 @@
                     <field id="enable" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label" type="select" canRestore="1">
                         <label>Enabled</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <config_path>reach/dhl/enable</config_path>
                     </field>
                     <field id="duty_label" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
                         <label>Tax and Duties Label</label>
                         <depends>
                             <field id="active">1</field>
                         </depends>
+                        <config_path>reach/dhl/duty_label</config_path>
                     </field>
                     <field id="allowspecific" translate="label" type="allowspecific" sortOrder="30"  showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                        <label>Enable tax and duty calculation</label>                    
+                        <label>Enable tax and duty calculation</label>
                         <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
                         <comment>Select the countries in which you'd like to enable tax and duty calculation</comment>
                         <config_path>reach/dhl/allowspecific</config_path>
@@ -83,32 +86,31 @@
                     <field id="specificcountry" translate="label" type="multiselect" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Enable tax and duty calculation</label>
                         <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-                            <can_be_empty>1</can_be_empty> 
-                        <config_path>reach/dhl/specificcountry</config_path>
+                        <can_be_empty>1</can_be_empty>
+                        <!-- No config path as it has no default -->
                     </field>
                     <field id="optional_allowspecific" translate="label" type="allowspecific" sortOrder="50"  showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                        <label>Make tax and duty optional</label>                    
-                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model> 
+                        <label>Make tax and duty optional</label>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
                         <comment>Select the countries in which you'd like to make it optional for the user to pay tax and duty cost</comment>
-                        <config_path>reach/dhl/optional_allowspecific</config_path>
+                        <!-- No config path as it has no default -->
                     </field>
                     <field id="optional_specificcountry" translate="label" type="multiselect" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Make tax and duty optional</label>
                         <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-                            <can_be_empty>1</can_be_empty> 
-                        <config_path>reach/dhl/optional_specificcountry</config_path>
+                        <can_be_empty>1</can_be_empty>
                     </field>
                     <field id="dhl_key" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="70" translate="label" type="text">
                         <label>DHL Client ID</label>
                         <depends>
                             <field id="active">1</field>
                         </depends>
-                        <config_path>reach/dhl/key</config_path>
+                        <!-- No config path as it has no default -->
                     </field>
                     <field id="applicable_shipping" translate="label" type="multiselect" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Tax and Duties Applicable to shipping</label>
-                        <source_model>Reach\Payment\Model\Config\Source\Carriers</source_model>    
-                        <config_path>reach/dhl/applicable_shipping</config_path>
+                        <source_model>Reach\Payment\Model\Config\Source\Carriers</source_model>
+                        <!-- No config path as it has no default -->
                     </field>
                     <field id="dhl_api_secret" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="80" translate="label" type="obscure">
                         <label>DHL Client Secret</label>
@@ -116,7 +118,7 @@
                         <depends>
                             <field id="active">1</field>
                         </depends>
-                        <config_path>reach/dhl/api_secret</config_path>
+                        <!-- No config path as it has no default -->
                     </field>
                     <field id="dhl_pickup_account" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="90" translate="label" type="text">
                         <label>DHL Pickup Account No.</label>
@@ -133,11 +135,12 @@
                         <config_path>reach/dhl/item_seller</config_path>
                     </field>
                     <field id="pref_tariffs" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="100" translate="label" type="select">
-                        <label>Qualifies for Preferential Tarrifs</label>
-                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <label>Qualifies for Preferential Tariffs</label>
+                        <source_model>Reach\Payment\Model\Config\Source\PrefTariffs</source_model>
                         <depends>
                             <field id="active">1</field>
                         </depends>
+                        <config_path>reach/dhl/pref_tariffs</config_path>
                     </field>
                     <field id="pricing_strategy" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="100" translate="label" type="select">
                         <label>DHL Pricing Strategy</label>
@@ -145,6 +148,7 @@
                         <depends>
                             <field id="active">1</field>
                         </depends>
+                        <config_path>reach/dhl/pricing_strategy</config_path>
                     </field>
                     <field id="clearance_mode" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="100" translate="label" type="select">
                         <label>Clearance Mode</label>
@@ -152,6 +156,7 @@
                         <depends>
                             <field id="active">1</field>
                         </depends>
+                        <config_path>reach/dhl/clearance_mode</config_path>
                     </field>
                     <field id="end_use" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="100" translate="label" type="select">
                         <label>End Use</label>
@@ -159,6 +164,7 @@
                         <depends>
                             <field id="active">1</field>
                         </depends>
+                        <config_path>reach/dhl/end_use</config_path>
                     </field>
                     <field id="transport_mode" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="100" translate="label" type="select">
                         <label>Transport Mode</label>
@@ -166,20 +172,21 @@
                         <depends>
                             <field id="active">1</field>
                         </depends>
+                        <config_path>reach/dhl/transport_mode</config_path>
                     </field>
                     <field id="default_hs_code" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="110" translate="label" type="text">
                         <label>Default HS Code</label>
                         <depends>
                             <field id="active">1</field>
                         </depends>
-                        <config_path>reach/dhl/default_hs_code</config_path>
+                        <!-- No config path as it has no default -->
                     </field>
                     <field id="export_csv_hs_code" translate="label" type="Reach\Payment\Block\Adminhtml\Form\Field\Export" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Export CSV of HS Code</label>
                         <depends>
                             <field id="active">1</field>
                         </depends>
-                        <config_path>reach/dhl/export_csv_hs_code</config_path>
+                        <!-- No config path as it has no default -->
                     </field>
                     <field id="import_csv_hs_code" translate="label" type="Reach\Payment\Block\Adminhtml\Form\Field\Import" showInStore="1" sortOrder="130" showInDefault="1" showInWebsite="1" >
                         <label>Import CSV of HS Code</label>
@@ -188,9 +195,9 @@
                         <depends>
                             <field id="active">1</field>
                         </depends>
-                        <config_path>reach/dhl/import_csv_hs_code</config_path>
+                        <!-- No config path as it has no default -->
                     </field>
-                </group>                     
+                </group>
                 <group id="reach_cc" showInDefault="1" showInStore="0" showInWebsite="1" sortOrder="200" translate="label comment" type="text">
                     <label>Reach Credit Card</label>
                     <depends>
@@ -199,12 +206,12 @@
                     <attribute type="expanded">1</attribute>
                     <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                     <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                        <label>Enabled</label>                        
-                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>    
+                        <label>Enabled</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/reach_cc/active</config_path>
                     </field>
                     <field id="title" sortOrder="2" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                        <label>Title</label>                        
+                        <label>Title</label>
                         <validate>required-entry</validate>
                         <config_path>payment/reach_cc/title</config_path>
                     </field>
@@ -214,10 +221,10 @@
                         <config_path>payment/reach_cc/allow_open_contract</config_path>
                     </field>
                     <field id="payment_action" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="0">
-                        <label>Payment Action</label>                        
+                        <label>Payment Action</label>
                         <source_model>Reach\Payment\Model\Config\Source\PaymentAction</source_model>
                         <config_path>payment/reach_cc/payment_action</config_path>
-                    </field>                    
+                    </field>
                     <field id="allowspecific" translate="label" type="allowspecific" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                         <label>Payment from Applicable Countries</label>
                         <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
@@ -255,7 +262,7 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>
                     <field id="title" sortOrder="2" translate="label" type="text" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                        <label>Title</label>                        
+                        <label>Title</label>
                         <validate>required-entry</validate>
                         <config_path>payment/reach_paypal/title</config_path>
                     </field>
@@ -263,7 +270,7 @@
                         <label>Payment Action</label>
                         <source_model>Reach\Payment\Model\Config\Source\PaymentAction</source_model>
                         <config_path>payment/reach_paypal/payment_action</config_path>
-                    </field>                    
+                    </field>
                     <field id="allowspecific" translate="label" type="allowspecific" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                         <label>Payment from Applicable Countries</label>
                         <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
@@ -274,7 +281,7 @@
                         <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
                         <can_be_empty>1</can_be_empty>
                         <config_path>payment/reach_paypal/specificcountry</config_path>
-                    </field>                     
+                    </field>
                     <field id="min_order_total" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="7" translate="label" type="text">
                         <label>Minimum Order Total</label>
                         <config_path>payment/reach_paypal/min_order_total</config_path>
@@ -287,8 +294,8 @@
                         <label>Sort Order</label>
                         <config_path>payment/reach_paypal/sort_order</config_path>
                     </field>
-                </group>   
+                </group>
             </group>
-        </section>        
+        </section>
     </system>
 </config>


### PR DESCRIPTION
This work is fixing errors related to various default configurations
in pre-existing work which are as follows:
* Reference to non existent XPATHs
* Rreference to existing but wrong XPATHs
* Missing references to XPATHs required to show correct default
values.

It fixed problems in options array for dropdowns.

Notes: The original PrefTariffs option array is Ryan's work.
I adjusted it to make it working. Same is true for Pricing Strategy.
PHPStorm did some whitespace cleanup which made the work
look like having more changes than it really has. I am told to
 submit it as is.

See Also: MAG-66, MAG-65