### PR TITLE
[MAG-104] Changed Config Path for Credit Card Sort Order

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -246,7 +246,7 @@
                     </field>
                     <field id="sort_order" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="15" translate="label" type="text">
                         <label>Sort Order</label>
-                        <config_path>payment/reach_cc/max_order_total</config_path>
+                        <config_path>payment/reach_cc/sort_order</config_path>
                     </field>
                 </group>
                 <group id="reach_paypal" showInDefault="1" showInStore="0" showInWebsite="1" sortOrder="200" translate="label comment" type="text">


### PR DESCRIPTION
Changed the `Config Path` that stores where on the UI the Credit Card info
appears with respect to other UI components.

Should be part of release 2.3.6