### PR TITLE
D-180 Merchant Id is blank - fix

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -52,7 +52,7 @@ class Data extends AbstractHelper
   const CONFIG_CURRENCY_ALLOW_SPECIFIC = 'reach/global/allowspecific';
   const CONFIG_CURRENCY_SPECIFIC_COUNTRY = 'reach/global/specificcountry';
   const CONFIG_API_MODE = 'reach/global/mode';
-  const CONFIG_MERCHANT_ID = 'reach/global/merchant_id';
+  const CONFIG_MERCHANT_ID = 'reach/global/mearchant_id';
   const CONFIG_API_SECRET = 'reach/global/api_secret';
 
 


### PR DESCRIPTION
Typo in one config key path.  It was corrected to the proper spelling at one time, but the old (incorrect) spelling should have been kept.  Descoped fixing it in the DB since it would have involved a DB migration step as part of the upgrade.