### PR TITLE
EXT-644: Error handling check for Message key

### DIFF
--- a/Model/PayPalManagement.php
+++ b/Model/PayPalManagement.php
@@ -328,7 +328,7 @@ class PayPalManagement implements \Reach\Payment\Api\PayPalManagementInterface
 
         if (isset($response['Error']) && count($response['Error'])) {
             $errorMessage = $response['Error']['Code'];
-            if ($response['Error']['Message'] != '') {
+            if (isset($response['Error']['Message']) && $response['Error']['Message'] != '') {
                 $errorMessage = ':'.$response['Error']['Message'];
             }
             throw new \Magento\Framework\Exception\LocalizedException(


### PR DESCRIPTION
- When an error is provided by the Checkout API, the Plugin assumes that the `Message` key will always be present. This is not the case.
- Added a conditional check to first determine if the `Message` key is present before attempting to use it.