### PR TITLE
[MAGENTO-18] Fixing the CC model to be configured as a payment gateway

### DIFF
--- a/Model/Cc.php
+++ b/Model/Cc.php
@@ -90,6 +90,12 @@ class Cc extends \Magento\Payment\Model\Method\Cc
      */
     protected $_clientTimeout = 45;
 
+    /**
+     * Payment Method feature
+     *
+     * @var bool
+     */
+    protected $_isGateway = true;
 
     /**
      * Payment Method feature


### PR DESCRIPTION
I double-checked this fix and it works.

When testing I checked:

- USD transaction, fully refunded: [fully refunded txn](https://sandbox.withreach.com/?txn=7f6a3641-3eb8-4932-95ce-ee1d5b0c5d3f)
- USD transaction, partially refunded until whole order is refunded: [fully refunded txn](https://sandbox.withreach.com/?txn=55d75568-fc92-4082-826b-36a45509ceb5)

When I tried to place a refund against a non-USD order (CAD) I ran into a separate bug and created this ticket [MAGENTO-36](https://withreach.atlassian.net/browse/MAGENTO-36)