### PR TITLE
MAGENTO-17: Implement webapi route for Notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.bash_history
+.composer-global/
+.idea/
+.ssh/

--- a/Api/NotificationInterface.php
+++ b/Api/NotificationInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Reach\Payment\Api;
+
+use Reach\Payment\Api\Data\ResponseInterface;
+
+/**
+ * @api
+ */
+interface NotificationInterface
+{
+    /**
+     * @param string $request
+     * @param string $signature
+     * @return ResponseInterface
+     */
+    public function handleNotification($request, $signature);
+}

--- a/Model/Cc.php
+++ b/Model/Cc.php
@@ -90,6 +90,12 @@ class Cc extends \Magento\Payment\Model\Method\Cc
      */
     protected $_clientTimeout = 45;
 
+    /**
+     * Payment Method feature
+     *
+     * @var bool
+     */
+    protected $_isGateway = true;
 
     /**
      * Payment Method feature
@@ -595,10 +601,7 @@ class Cc extends \Magento\Payment\Model\Method\Cc
      */
     private function getCallbackUrl($order)
     {
-        $url = $this->coreUrl->getUrl('reach/cc/callback', [
-            '_secure' => true,
-            '_store'  => $order->getStoreId()
-        ]);
+        $url = $this->coreUrl->getUrl('rest/default/V1/reach/notification');
         $url .= "?orderid=" . $order->getQuoteId();
         return  $url;
     }

--- a/Model/Cc.php
+++ b/Model/Cc.php
@@ -482,7 +482,7 @@ class Cc extends \Magento\Payment\Model\Method\Cc
         $request['Consumer'] = $consumer;
         
         
-        $request['Notify'] = $this->getCallbackUrl($order);
+        $request['Notify'] = $this->getNotifyUrl($order);
         $request['ConsumerCurrency']= $order->getOrderCurrencyCode();
 
         $rateOfferId =  $this->reachCurrency->getOfferId($order->getOrderCurrencyCode());
@@ -599,7 +599,7 @@ class Cc extends \Magento\Payment\Model\Method\Cc
      * @param object $order
      * @return string
      */
-    private function getCallbackUrl($order)
+    private function getNotifyUrl($order)
     {
         $url = $this->coreUrl->getUrl('rest/default/V1/reach/notification');
         $url .= "?orderid=" . $order->getQuoteId();

--- a/Model/PostbackNotification/Decoder.php
+++ b/Model/PostbackNotification/Decoder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Reach\Payment\Model\PostbackNotification;
+
+use Magento\Framework;
+
+class Decoder implements DecoderInterface
+{
+    /**s
+     * Decodes the given $data string which is encoded in the x-www-form-urlencoded format.
+     *
+     * @param string $data
+     * @return mixed
+     */
+    public function decode($data)
+    {
+        parse_str($data, $result);
+
+        return $result;
+    }
+}

--- a/Model/PostbackNotification/DecoderInterface.php
+++ b/Model/PostbackNotification/DecoderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Reach\Payment\Model\PostbackNotification;
+
+/**
+ * JSON decoder
+ *
+ * @api
+ */
+interface DecoderInterface
+{
+    /**
+     * Decodes the given $data string which is encoded in the x-www-form-urlencoded format into a PHP type (array, string literal, etc.)
+     *
+     * @param string $data
+     * @return mixed
+     */
+    public function decode($data);
+}

--- a/Model/ReachNotification.php
+++ b/Model/ReachNotification.php
@@ -56,7 +56,12 @@ class ReachNotification implements NotificationInterface
             if ($this->validate($request, $signature)) {
                 // TODO:: Handle other Notification order states
                 $response = json_decode($request, true);
-                if (isset($response['OrderState']) && $response['OrderState'] == "Processed" && $response['UnderReview'] === false && !count($response['Refunds'])) {
+
+                $isProcessed = isset($response['OrderState']) && $response['OrderState'] == "Processed";
+                $isNotUnderReview = $response['UnderReview'] === false;
+                $hasNoRefunds = !count($response['Refunds']);
+
+                if ($isProcessed && $isNotUnderReview && $hasNoRefunds) {
                     $order = $this->loadOrder($response['ReferenceId']);
                     $order = $this->orderRepository->get($order->getId());
                     $order->getPayment()->accept();

--- a/Model/ReachNotification.php
+++ b/Model/ReachNotification.php
@@ -1,58 +1,81 @@
 <?php
 
-namespace Reach\Payment\Controller\Cc;
+namespace Reach\Payment\Model;
 
+use Reach\Payment\Api\Data\ResponseInterface;
+use Reach\Payment\Api\NotificationInterface;
+use Magento\Framework\Webapi\Exception;
+use Magento\Framework\Phrase;
 use Magento\Sales\Api\OrderRepositoryInterface;
 
-class Callback extends \Magento\Framework\App\Action\Action
+/**
+ * ReachCurrency model
+ *
+ */
+class ReachNotification implements NotificationInterface
 {
-
+    /** @var ResponseInterface  */
+    protected $response;
 
     /**
-     *
-     * @param \Magento\Framework\App\Action\Context $context
-     * @param \Magento\Checkout\Model\Session $checkoutSession
-     * @param \Magento\Quote\Model\Quote $quote
-     * @param \Magento\Sales\Model\OrderFactory $orderFactory
-     * @param \Magento\Quote\Model\QuoteFactory $quoteFactory
+     * @var \Reach\Payment\Helper\Data
      */
+    protected $reachHelper;
+
+    /**
+     * @var \Magento\Sales\Model\OrderFactory
+     */
+    protected $_orderFactory;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    protected $orderRepository;
+
     public function __construct(
-        \Magento\Framework\App\Action\Context $context,
+        ResponseInterface $response,
         \Reach\Payment\Helper\Data $reachHelper,
         \Magento\Sales\Model\OrderFactory $orderFactory,
         OrderRepositoryInterface $orderRepository
     ) {
-        parent::__construct($context);
+        $this->response = $response;
         $this->reachHelper = $reachHelper;
         $this->_orderFactory       = $orderFactory;
         $this->orderRepository = $orderRepository;
     }
 
     /**
-     * @throws LocalizedException
+     * @param $request
+     * @param $signature
+     * @return ResponseInterface
      */
-    public function execute()
+    public function handleNotification($request, $signature)
     {
-        $params = $this->getRequest()->getParams();    
         try {
-            if (isset($params['request']) && isset($params['signature']) && $this->validate($params['request'], $params['signature'])) {
-                $response = json_decode($params['request'], true);
+            if ($this->validate($request, $signature)) {
+                // TODO:: Handle other Notification order states
+                $response = json_decode($request, true);
                 if (isset($response['OrderState']) && $response['OrderState'] == "Processed" && $response['UnderReview'] === false && !count($response['Refunds'])) {
                     $order = $this->loadOrder($response['ReferenceId']);
                     $order = $this->orderRepository->get($order->getId());
                     $order->getPayment()->accept();
                     $this->orderRepository->save($order);
                     $order->getInvoiceCollection()
-                    ->setDataToAll('transaction_id', $response['OrderId'])
-                    ->save();
+                        ->setDataToAll('transaction_id', $response['OrderId'])
+                        ->save();
+
+                    $this->response->setSuccess(true);
+                    $this->response->setResponse('Successfully processed Notification');
+                } else {
+                    $this->response->setSuccess(true);
+                    $this->response->setResponse('Unhandled Notification State');
                 }
             }
         } catch (\Exception $e) {
-            $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/cc-callback-error.log');
-            $logger = new \Zend\Log\Logger();
-            $logger->addWriter($writer);
-            $logger->info($e->getMessage());
+            throw new Exception(new Phrase($e->getMessage()), 400, 404);
         }
+
+        return $this->response;
     }
 
     private function validate($request, $nonce)
@@ -65,7 +88,7 @@ class Callback extends \Magento\Framework\App\Action\Action
     private function loadOrder($incrementId)
     {
         $order = $this->_order = $this->_orderFactory->create()->loadByIncrementId($incrementId);
-        
+
         if ($order === null || $order->getId() === null) {
             throw new \Magento\Framework\Exception\LocalizedException(__("Invalid order."));
         }

--- a/Model/ReachNotification.php
+++ b/Model/ReachNotification.php
@@ -9,12 +9,12 @@ use Magento\Framework\Phrase;
 use Magento\Sales\Api\OrderRepositoryInterface;
 
 /**
- * ReachCurrency model
+ * ReachNotification model
  *
  */
 class ReachNotification implements NotificationInterface
 {
-    /** @var ResponseInterface  */
+    /** @var ResponseInterface */
     protected $response;
 
     /**
@@ -33,14 +33,15 @@ class ReachNotification implements NotificationInterface
     protected $orderRepository;
 
     public function __construct(
-        ResponseInterface $response,
-        \Reach\Payment\Helper\Data $reachHelper,
+        ResponseInterface                 $response,
+        \Reach\Payment\Helper\Data        $reachHelper,
         \Magento\Sales\Model\OrderFactory $orderFactory,
-        OrderRepositoryInterface $orderRepository
-    ) {
+        OrderRepositoryInterface          $orderRepository
+    )
+    {
         $this->response = $response;
         $this->reachHelper = $reachHelper;
-        $this->_orderFactory       = $orderFactory;
+        $this->_orderFactory = $orderFactory;
         $this->orderRepository = $orderRepository;
     }
 
@@ -72,7 +73,7 @@ class ReachNotification implements NotificationInterface
                 }
             }
         } catch (\Exception $e) {
-            throw new Exception(new Phrase($e->getMessage()), 400, 404);
+            throw new Exception(new Phrase($e->getMessage()));
         }
 
         return $this->response;
@@ -81,7 +82,7 @@ class ReachNotification implements NotificationInterface
     private function validate($request, $nonce)
     {
         $key = $this->reachHelper->getSecret();
-        $signature =  base64_encode(hash_hmac('sha256', $request, $key, true));
+        $signature = base64_encode(hash_hmac('sha256', $request, $key, true));
         return $signature == $nonce;
     }
 

--- a/Webapi/Rest/Request/Deserializer/XWwwFormUrlencoded.php
+++ b/Webapi/Rest/Request/Deserializer/XWwwFormUrlencoded.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Reach\Payment\Webapi\Rest\Request\Deserializer;
+
+
+use Magento\Framework\App\State;
+use Magento\Framework\Phrase;
+use Reach\Payment\Model\PostbackNotification\Decoder;
+
+class XWwwFormUrlencoded implements \Magento\Framework\Webapi\Rest\Request\DeserializerInterface
+{
+
+    /** @var Decoder */
+    protected $decoder;
+
+    /**
+     * @var State
+     */
+    protected $_appState;
+
+    /**
+     * @param Decoder $decoder
+     * @param \Magento\Framework\App\State $appState
+     */
+    public function __construct(Decoder $decoder, State $appState)
+    {
+        $this->decoder = $decoder;
+        $this->_appState = $appState;
+    }
+
+    /**
+     * Parse Request body into array of params.
+     *
+     * @param string $encodedBody Posted content from request.
+     * @return array|null Return NULL if content is invalid.
+     * @throws \Exception
+     * @throws \Magento\Framework\Webapi\Exception If decoding error was encountered.
+     */
+    public function deserialize($encodedBody)
+    {
+        if (!is_string($encodedBody)) {
+            throw new \InvalidArgumentException(
+                sprintf('"%s" data type is invalid. String is expected.', gettype($encodedBody))
+            );
+        }
+        try {
+            $decodedBody = $this->decoder->decode($encodedBody);
+        } catch (\Exception $e) {
+            if ($this->_appState->getMode() !== State::MODE_DEVELOPER) {
+                throw new \Magento\Framework\Webapi\Exception(new Phrase('Decoding error.'));
+            } else {
+                throw new \Magento\Framework\Webapi\Exception(
+                    new Phrase(
+                        'Decoding error: %1%2%3%4',
+                        [PHP_EOL, $e->getMessage(), PHP_EOL, $e->getTraceAsString()]
+                    )
+                );
+            }
+        }
+        return $decodedBody;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -12,8 +12,38 @@
     <preference for="Reach\Payment\Api\DutyCalculatorInterface" type="Reach\Payment\Model\DutyCalculator" />
     <preference for="Reach\Payment\Api\GuestDutyCalculatorInterface" type="Reach\Payment\Model\GuestDutyCalculator" />
 
+    <preference for="Reach\Payment\Api\NotificationInterface" type="Reach\Payment\Model\ReachNotification" />
+
     <preference for="Reach\Payment\Api\Data\StashResponseInterface" type="Reach\Payment\Model\Api\Data\StashResponse" />
     <preference for="Reach\Payment\Api\Data\DutyResponseInterface" type="Reach\Payment\Model\Api\Data\DutyResponse" />
     <preference for="Reach\Payment\Api\Data\ResponseInterface" type="Reach\Payment\Model\Api\Data\Response" />
     <preference for="Reach\Payment\Api\Data\HttpResponseInterface" type="Reach\Payment\Model\Api\Data\HttpResponse" />
+    <preference for="Reach\Payment\Api\Data\NotificationResponseInterface" type="Reach\Payment\Model\Api\Data\NotificationResponse" />
+
+    <type name="Magento\Framework\Webapi\Rest\Request\DeserializerFactory">
+        <arguments>
+            <argument name="deserializers" xsi:type="array">
+                <item name="application_x_www_form_urlencoded" xsi:type="array">
+                    <item name="type" xsi:type="string">application/x-www-form-urlencoded</item>
+                    <item name="model" xsi:type="string">Reach\Payment\Webapi\Rest\Request\Deserializer\XWwwFormUrlencoded</item>
+                </item>
+                <item name="application_json" xsi:type="array">
+                    <item name="type" xsi:type="string">application/json</item>
+                    <item name="model" xsi:type="string">Magento\Framework\Webapi\Rest\Request\Deserializer\Json</item>
+                </item>
+                <item name="application_xml" xsi:type="array">
+                    <item name="type" xsi:type="string">application/xml</item>
+                    <item name="model" xsi:type="string">Magento\Framework\Webapi\Rest\Request\Deserializer\Xml</item>
+                </item>
+                <item name="application_xhtml_xml" xsi:type="array">
+                    <item name="type" xsi:type="string">application/xhtml+xml</item>
+                    <item name="model" xsi:type="string">Magento\Framework\Webapi\Rest\Request\Deserializer\Xml</item>
+                </item>
+                <item name="text_xml" xsi:type="array">
+                    <item name="type" xsi:type="string">text/xml</item>
+                    <item name="model" xsi:type="string">Magento\Framework\Webapi\Rest\Request\Deserializer\Xml</item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -31,4 +31,10 @@
             <resource ref="anonymous" />
         </resources>
     </route>
+    <route url="/V1/reach/notification" method="POST">
+        <service class="Reach\Payment\Api\NotificationInterface" method="handleNotification"/>
+        <resources>
+            <resource ref="anonymous" />
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
- Created a new webapi route for handling the Reach Notifications
- Needed override the `DeserializerFactory` in order to be able to handle the `x-www-form-url-encoded` request that is coming from the Checkout API
- Replaced the `Notify` URL with the webapi route endpoint
- Removed the `Callback` Controller