### PR TITLE
Fixing refunds for PayPal

### DIFF
--- a/Controller/Paypal/Processing.php
+++ b/Controller/Paypal/Processing.php
@@ -3,6 +3,8 @@
 
 namespace Reach\Payment\Controller\Paypal;
 
+use Magento\Sales\Api\Data\TransactionInterface;
+
 class Processing extends \Magento\Framework\App\Action\Action
 {
     /**
@@ -87,6 +89,7 @@ class Processing extends \Magento\Framework\App\Action\Action
                 $action = \Magento\Sales\Model\Order\Payment\Transaction::TYPE_CAPTURE;
             }
 
+            /** @var TransactionInterface $transaction */
             $transaction = $this->transactionFactory->create();
             $transaction->setOrderPaymentObject($payment);
             $transaction->setTxnId($response['OrderId']);
@@ -167,9 +170,7 @@ class Processing extends \Magento\Framework\App\Action\Action
      */
     private function setTransactionData($transactionId, $payment, $orderState)
     {
-        $transactionId = str_replace('-', '', $transactionId);
         if (!empty($transactionId) && $payment->getLastTransId() == $transactionId) {
-            $payment->setLastTransId($transactionId);
             $payment->setAdditionalInformation('orderState', $orderState);
             $payment->save();
         } else {

--- a/Model/PayPalManagement.php
+++ b/Model/PayPalManagement.php
@@ -2,6 +2,8 @@
 
 namespace Reach\Payment\Model;
 
+use Magento\Sales\Model\Order\Payment;
+
 /**
  * PaypalManagement model
  *
@@ -363,20 +365,17 @@ class PayPalManagement implements \Reach\Payment\Api\PayPalManagementInterface
     }
 
     /**
-     * @param DataObject $payment
+     * @param Payment $payment
      * @param DataObject $response
      * @return Object
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function setTransStatus($payment, $response)
     {
-
         if (isset($response['OrderId']) && isset($response['Action'])) {
             $payment->setTransactionId($response['OrderId']);
-
-            //as magento allows to store only 32 character for transaction id, removing - to store it
-            $trn = str_replace('-', '', $response['OrderId']);
-            $payment->setLastTransId($trn);
+            $payment->setParentTransactionId($response['OrderId']);
+            $payment->setLastTransId($response['OrderId']);
             $payment->setAdditionalInformation('Action', $response['Action']);
             $payment->setAdditionalInformation('OrderId', $response['OrderId']);
             

--- a/Model/Paypal.php
+++ b/Model/Paypal.php
@@ -85,7 +85,7 @@ class Paypal extends \Magento\Payment\Model\Method\AbstractMethod
      *
      * @var bool
      */
-    protected $_canRefund = false;
+    protected $_canRefund = true;
 
     /**
      * Availability option
@@ -309,10 +309,9 @@ class Paypal extends \Magento\Payment\Model\Method\AbstractMethod
     public function refund(\Magento\Payment\Model\InfoInterface $payment, $amount)
     {
         $request=[];
-        $request['OrderId'] = str_replace('-capture','',$payment->getParentTransactionId());
+        $request['OrderId'] = $payment->getAdditionalInformation('OrderId');
         $request['MerchantId']= $this->reachHelper->getMerchantId();
         $request['Amount']= $amount;
-        $request['ReferenceId']=$payment->getParentTransactionId();
         $request['ReferenceId']=$this->getReferenceIdForRefund($payment);
         $url = $this->reachHelper->getRefundUrl();
         $response = $this->callCurl($url,$request);


### PR DESCRIPTION
Refunds for PayPal was not working at all, regardless of the currency used. The underlying issue is that when a request is made to the /refund endpoint the OrderId and ReferenceId provided are not provided as expected. Therefore the request was failing. This fix ensures that the correct values are stored for the original payment made using Reach PayPal, which would allow the refund request to have the correct values associated to the refund request.