### PR TITLE
Non base refund failure fix

### DIFF
--- a/Model/Cc.php
+++ b/Model/Cc.php
@@ -59,7 +59,7 @@ class Cc extends \Magento\Payment\Model\Method\Cc
      *
      * @var bool
      */
-    protected $_canRefund = false;
+    protected $_canRefund = true;
 
     /**
      * Availability option
@@ -418,7 +418,7 @@ class Cc extends \Magento\Payment\Model\Method\Cc
         $request=[];
         $request['OrderId'] = str_replace('-capture', '', $payment->getParentTransactionId());
         $request['MerchantId']= $this->reachHelper->getMerchantId();
-        $request['Amount']= $amount;
+        $request['Amount']= $this->reachCurrency->convertCurrency($payment->getOrder()->getOrderCurrencyCode(), $payment->getCreditmemo()->getGrandTotal());
         $request['ReferenceId']=$this->getReferenceIdForRefund($payment);
         $url = $this->reachHelper->getRefundUrl();
         $response = $this->callCurl($url, $request);

--- a/Model/Cc.php
+++ b/Model/Cc.php
@@ -415,10 +415,12 @@ class Cc extends \Magento\Payment\Model\Method\Cc
      */
     public function refund(\Magento\Payment\Model\InfoInterface $payment, $amount)
     {
+        $currencyCode = $payment->getOrder()->getOrderCurrencyCode();
+        $refundGrandTotalInConsumerCurrency = $payment->getCreditmemo()->getGrandTotal();
         $request=[];
         $request['OrderId'] = str_replace('-capture', '', $payment->getParentTransactionId());
         $request['MerchantId']= $this->reachHelper->getMerchantId();
-        $request['Amount']= $this->reachCurrency->convertCurrency($payment->getOrder()->getOrderCurrencyCode(), $payment->getCreditmemo()->getGrandTotal());
+        $request['Amount']= $this->reachCurrency->convertCurrency($currencyCode, $refundGrandTotalInConsumerCurrency);
         $request['ReferenceId']=$this->getReferenceIdForRefund($payment);
         $url = $this->reachHelper->getRefundUrl();
         $response = $this->callCurl($url, $request);

--- a/Model/Paypal.php
+++ b/Model/Paypal.php
@@ -311,7 +311,7 @@ class Paypal extends \Magento\Payment\Model\Method\AbstractMethod
         $request=[];
         $request['OrderId'] = $payment->getAdditionalInformation('OrderId');
         $request['MerchantId']= $this->reachHelper->getMerchantId();
-        $request['Amount']= $amount;
+        $request['Amount']= $this->reachCurrency->convertCurrency($payment->getOrder()->getOrderCurrencyCode(), $payment->getCreditmemo()->getGrandTotal());
         $request['ReferenceId']=$this->getReferenceIdForRefund($payment);
         $url = $this->reachHelper->getRefundUrl();
         $response = $this->callCurl($url,$request);
@@ -570,7 +570,7 @@ class Paypal extends \Magento\Payment\Model\Method\AbstractMethod
     * @throws \Magento\Framework\Exception\LocalizedException
     */
     protected function callCurl($url,$params,$method="POST")
-    {        
+    {
         $json = json_encode($params);
         $secret = $this->reachHelper->getSecret();
         $signature = base64_encode(hash_hmac('sha256', $json,$secret, TRUE));

--- a/Model/Paypal.php
+++ b/Model/Paypal.php
@@ -308,10 +308,12 @@ class Paypal extends \Magento\Payment\Model\Method\AbstractMethod
      */
     public function refund(\Magento\Payment\Model\InfoInterface $payment, $amount)
     {
+        $currencyCode = $payment->getOrder()->getOrderCurrencyCode();
+        $refundGrandTotalInConsumerCurrency = $payment->getCreditmemo()->getGrandTotal();
         $request=[];
         $request['OrderId'] = $payment->getAdditionalInformation('OrderId');
         $request['MerchantId']= $this->reachHelper->getMerchantId();
-        $request['Amount']= $this->reachCurrency->convertCurrency($payment->getOrder()->getOrderCurrencyCode(), $payment->getCreditmemo()->getGrandTotal());
+        $request['Amount']= $this->reachCurrency->convertCurrency($currencyCode, $refundGrandTotalInConsumerCurrency);
         $request['ReferenceId']=$this->getReferenceIdForRefund($payment);
         $url = $this->reachHelper->getRefundUrl();
         $response = $this->callCurl($url,$request);


### PR DESCRIPTION
Refund request was sending in base currency and not consumer currency causing `RefundLimitExceeded` in some instances. 

Fix: grab `getGrandTotal()` from the credit memo which is the grand total of the refund from the credit memo in the purchase currency (consumer currency).