### PR TITLE
Fixing the credit memo issue with duties

### DIFF
--- a/Block/Adminhtml/Sales/Order/Creditmemo/Totals.php
+++ b/Block/Adminhtml/Sales/Order/Creditmemo/Totals.php
@@ -45,21 +45,25 @@ class Totals extends \Magento\Framework\View\Element\Template
      */
     public function initTotals()
     {
-        $this->getParentBlock();
-        $this->getCreditmemo();
-        $this->getSource();
-        if (!$this->getSource()->getReachDuty()) {
+        /** @var \Magento\Sales\Block\Order\Totals $parent */
+        $parent = $this->getParentBlock();
+        $source = $this->getSource();
+
+        if (!$source->getReachDuty()) {
             return $this;
         }
+
         $total = new \Magento\Framework\DataObject(
             [
                 'code' => 'reach_duty',
-                'value' => $this->getSource()->getReachDuty(),
+                'value' => $source->getReachDuty(),
                 'label' => 'Tax & Duties',
-                'base_value' => $this->getSource()->getBaseReachDuty()
+                'base_value' => $source->getBaseReachDuty()
             ]
         );
-        $this->getParentBlock()->addTotalBefore($total, 'grand_total');
+
+        $parent->addTotalBefore($total, 'grand_total');
+
         return $this;
     }
 }

--- a/Model/Creditmemo/Total/Duty.php
+++ b/Model/Creditmemo/Total/Duty.php
@@ -14,9 +14,13 @@ class Duty extends AbstractTotal
     public function collect(\Magento\Sales\Model\Order\Creditmemo $creditmemo)
     {
         $creditmemo->setReachDuty(0);
-        $amount = $creditmemo->getOrder()->getReachDuty();
-        $creditmemo->setReachDuty($amount);
-        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $amount);
+        $reachDuty = $creditmemo->getOrder()->getReachDuty();
+        $baseReachDuty = $creditmemo->getOrder()->getBaseReachDuty();
+        $creditmemo->setReachDuty($reachDuty);
+        $creditmemo->setBaseReachDuty($baseReachDuty);
+        $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $reachDuty);
+        $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $baseReachDuty);
+
         return $this;
     }
 }

--- a/Model/Invoice/Total/Duty.php
+++ b/Model/Invoice/Total/Duty.php
@@ -13,9 +13,12 @@ class Duty extends AbstractTotal
     public function collect(\Magento\Sales\Model\Order\Invoice $invoice)
     {
         $invoice->setReachDuty(0);
-        $amount = $invoice->getOrder()->getReachDuty();
-        $invoice->setReachDuty($amount);
-        $invoice->setGrandTotal($invoice->getGrandTotal() + $amount);
+        $reachDuty = $invoice->getOrder()->getReachDuty();
+        $baseReachDuty = $invoice->getOrder()->getBaseReachDuty();
+        $invoice->setReachDuty($reachDuty);
+        $invoice->setBaseReachDuty($baseReachDuty);
+        $invoice->setGrandTotal($invoice->getGrandTotal() + $reachDuty);
+        $invoice->setBaseGrandTotal($invoice->getBaseGrandTotal() + $baseReachDuty);
         return $this;
     }
 }

--- a/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
+++ b/view/adminhtml/layout/sales_order_creditmemo_updateqty.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+          <referenceBlock name="creditmemo_totals">
+            <block class="Reach\Payment\Block\Adminhtml\Sales\Order\Creditmemo\Totals"
+                   name="duty" as="duty"/>
+        </referenceBlock>
+    </body>
+</page>


### PR DESCRIPTION
- Fixing the issue around the duties not being included when a credit
memo is included
- Properly adding the base Reach duty to the grand total
- Overriding the `sale_order_creditmemo_updatedqty.xml` to ensure that
the "Tax & Duties" is displayed in the admin

Note: A full refund works (including the tax and duties) as expected, however if a merchant wanted to
create a partial refund and does not want to refund the "Tax & Duties"
then they will need to offset the amount using Adjustment Fee.