### PR TITLE
return generic auth fail for fraud related rejections for CC and Paypal

### DIFF
--- a/Model/Cc.php
+++ b/Model/Cc.php
@@ -693,7 +693,7 @@ class Cc extends \Magento\Payment\Model\Method\Cc
         if (isset($response['Error']) && count($response['Error'])) {
             $error = $response['Error']['Code'];
             if (isset($error) && $error != '') {
-                if ($error == "Blacklisted" || $error == "FraudSuspected") {
+                if ($error === "Blacklisted" || $error === "FraudSuspected") {
                     $errorMessage = ': PaymentAuthorizationFailed';
                 } else {
                     $errorMessage = ':'.$error;

--- a/Model/Cc.php
+++ b/Model/Cc.php
@@ -690,14 +690,17 @@ class Cc extends \Magento\Payment\Model\Method\Cc
      */
     public function processErrors($response)
     {
-
         if (isset($response['Error']) && count($response['Error'])) {
-            $errorMessage = $response['Error']['Code'];
-            if (isset($response['Error']['Message']) && $response['Error']['Message'] != '') {
-                $errorMessage = ':'.$response['Error']['Message'];
+            $error = $response['Error']['Code'];
+            if (isset($error) && $error != '') {
+                if ($error == "Blacklisted" || $error == "FraudSuspected") {
+                    $errorMessage = ': PaymentAuthorizationFailed';
+                } else {
+                    $errorMessage = ':'.$error;
+                }
             }
             throw new \Magento\Framework\Exception\LocalizedException(
-                __($errorMessage)
+                __('Something went wrong while generating the payment request: ' .$errorMessage)
             );
         }
     }

--- a/Model/Cc.php
+++ b/Model/Cc.php
@@ -694,9 +694,9 @@ class Cc extends \Magento\Payment\Model\Method\Cc
             $error = $response['Error']['Code'];
             if (isset($error) && $error != '') {
                 if ($error === "Blacklisted" || $error === "FraudSuspected") {
-                    $errorMessage = ': PaymentAuthorizationFailed';
+                    $errorMessage = 'PaymentAuthorizationFailed';
                 } else {
-                    $errorMessage = ':'.$error;
+                    $errorMessage = $error;
                 }
             }
             throw new \Magento\Framework\Exception\LocalizedException(

--- a/Model/PayPalManagement.php
+++ b/Model/PayPalManagement.php
@@ -150,8 +150,14 @@ class PayPalManagement implements \Reach\Payment\Api\PayPalManagementInterface
             }
         } catch (\Exception $e) {
             $this->response->setSuccess(false);
+            $error = $e->getMessage();
+            if ($error == "Blacklisted" || $error == "FraudSuspected") {
+                $errorMessage = ': PaymentAuthorizationFailed';
+            } else {
+                $errorMessage = $error;
+            }
             $this->response->setErrorMessage(
-                __('Something went wrong while generating the paypal request: ' . $e->getMessage())
+                __('Something went wrong while generating the paypal request: ' . $errorMessage)
             );
         }
 

--- a/Model/PayPalManagement.php
+++ b/Model/PayPalManagement.php
@@ -152,7 +152,7 @@ class PayPalManagement implements \Reach\Payment\Api\PayPalManagementInterface
             $this->response->setSuccess(false);
             $error = $e->getMessage();
             if ($error === "Blacklisted" || $error === "FraudSuspected") {
-                $errorMessage = ': PaymentAuthorizationFailed';
+                $errorMessage = 'PaymentAuthorizationFailed';
             } else {
                 $errorMessage = $error;
             }

--- a/Model/PayPalManagement.php
+++ b/Model/PayPalManagement.php
@@ -151,7 +151,7 @@ class PayPalManagement implements \Reach\Payment\Api\PayPalManagementInterface
         } catch (\Exception $e) {
             $this->response->setSuccess(false);
             $error = $e->getMessage();
-            if ($error == "Blacklisted" || $error == "FraudSuspected") {
+            if ($error === "Blacklisted" || $error === "FraudSuspected") {
                 $errorMessage = ': PaymentAuthorizationFailed';
             } else {
                 $errorMessage = $error;


### PR DESCRIPTION
When a transaction is rejected by Reach due to Reach's fraud or Reach's Denylist Magento is displaying the error returned by Reach's Chekcout API directly to the customer which could tip-off fraudsters. To fix this, we will return a generic `PaymentAuthorizationFailed` error.

Reach Errors to be generic:
- Blacklisted 
- FraudSuspected 
