### PR TITLE
Only return Saved Cards/Contracts tied to Customer Selected Currency

### DIFF
--- a/Block/Customer/Savedcard.php
+++ b/Block/Customer/Savedcard.php
@@ -38,7 +38,7 @@ class Savedcard extends \Magento\Framework\View\Element\Template
         $customerCards = $this->getCustomerCards();
         if ($customerCards && $customerCards->count()) {
             foreach ($customerCards as $card) {
-                $cards[]=['type'=>$card->getMethod(),'number'=>$card->getIdentifier(),'contract_id'=>$card->getId()];
+                $cards[]=['type'=>$card->getMethod(),'number'=>$card->getIdentifier(),'contract_id'=>$card->getId(), 'currency'=>$card->getcurrency()];
             }
         }
         return $cards;

--- a/Block/Customer/Savedcard.php
+++ b/Block/Customer/Savedcard.php
@@ -38,7 +38,13 @@ class Savedcard extends \Magento\Framework\View\Element\Template
         $customerCards = $this->getCustomerCards();
         if ($customerCards && $customerCards->count()) {
             foreach ($customerCards as $card) {
-                $cards[]=['type'=>$card->getMethod(),'number'=>$card->getIdentifier(),'contract_id'=>$card->getId(), 'currency'=>$card->getcurrency()];
+                $cards[]=
+                    [
+                        'type'=>$card->getMethod(),
+                        'number'=>$card->getIdentifier(),
+                        'contract_id'=>$card->getId(),
+                        'currency'=>$card->getcurrency()
+                    ];
             }
         }
         return $cards;

--- a/Model/CcConfigProvider.php
+++ b/Model/CcConfigProvider.php
@@ -138,7 +138,12 @@ class CcConfigProvider implements ConfigProviderInterface
             $collection = $this->openContract->getCollection();
             $collection->addFieldToFilter('customer_id', ['eq'=>$customerId]);
             foreach ($collection as $contract) {
-                $contracts[] = ['contractId'=>$contract->getReachContractId(),'label'=>$contract->getMethod().' - '.$contract->getIdentifier(), 'contractCurrency'=>$contract->getCurrency()];
+                $contracts[] =
+                    [
+                        'contractId'=>$contract->getReachContractId(),
+                        'label'=>$contract->getMethod().' - '.$contract->getIdentifier(),
+                        'contractCurrency'=>$contract->getCurrency()
+                    ];
             }
         }
         return $contracts;

--- a/view/frontend/web/js/view/payment/method-renderer/cc.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cc.js
@@ -26,17 +26,19 @@ define([
         
         var isLoggedIn = ko.observable(window.isCustomerLoggedIn);
         var contractOptions=[];
+        var selectedCurrency = window.checkoutConfig.payment.reach_cc.selected_currency;
         if (isLoggedIn()) {
             if (typeof window.checkoutConfig.payment.reach_cc.open_contracts !== 'undefined' &&
                     window.checkoutConfig.payment.reach_cc.open_contracts.length)
             {
                 var contracts = window.checkoutConfig.payment.reach_cc.open_contracts;
                 $.each(contracts, function (key, item) {
-                    contractOptions.push(item);
+                    if(item.contractCurrency === selectedCurrency){
+                        contractOptions.push(item);
+                    }
                 });
                 contractOptions.push({contractId:0,label:$t('Use Different Card')});
-            }  
-            console.log(contractOptions);            
+            }
         }
         return Component.extend({
             defaults: {
@@ -238,6 +240,7 @@ define([
                 {
                     return false;
                 }
+                console.log("herererere")
                 return typeof window.checkoutConfig.payment.reach_cc.oc_enabled !== 'undefined' &&
                     window.checkoutConfig.payment.reach_cc.oc_enabled === true;
             }

--- a/view/frontend/web/js/view/payment/method-renderer/cc.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cc.js
@@ -240,7 +240,6 @@ define([
                 {
                     return false;
                 }
-                console.log("herererere")
                 return typeof window.checkoutConfig.payment.reach_cc.oc_enabled !== 'undefined' &&
                     window.checkoutConfig.payment.reach_cc.oc_enabled === true;
             }


### PR DESCRIPTION
Contracts can only be used with the currency the contract was opened with. 

When presenting the saved cards (contracts) to the customer only saved cards (contracts) with the correct currency will be displayed.