### PR TITLE
Set closed at date for Reach contracts

### DIFF
--- a/Api/ContractRepositoryInterface.php
+++ b/Api/ContractRepositoryInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Reach\Payment\Api;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Reach\Payment\Api\Data\ContractInterface;
+use Reach\Payment\Api\Data\ContractSearchResultInterface;
+
+/**
+ * @api
+ */
+interface ContractRepositoryInterface
+{
+    /**
+     * @param int $id
+     * @return ContractInterface
+     * @throws NoSuchEntityException
+     */
+    public function getById($id);
+
+    /**
+     * @param ContractInterface $contract
+     * @return ContractInterface
+     * @throws CouldNotSaveException
+     */
+    public function save(ContractInterface $contract);
+
+    /**
+     * @param ContractInterface $contract
+     * @return bool true on success
+     * @throws CouldNotDeleteException
+     */
+    public function delete(ContractInterface $contract);
+
+    /**
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return ContractSearchResultInterface
+     * @throws LocalizedException
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria);
+}

--- a/Api/Data/ContractInterface.php
+++ b/Api/Data/ContractInterface.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Reach\Payment\Api\Data;
+
+interface ContractInterface
+{
+    /**
+     * @return int
+     */
+    public function getContractId();
+
+    /**
+     * @param int $contractId
+     * @return void
+     */
+    public function setContractId($contractId);
+
+    /**
+     * @return int
+     */
+    public function getCustomerId();
+
+    /**
+     * @param int $customerId
+     * @return void
+     */
+    public function setCustomerId($customerId);
+
+    /**
+     * @return string
+     */
+    public function getReachContractId();
+
+    /**
+     * @param string $contractId
+     * @return void
+     */
+    public function setReachContractId($contractId);
+
+    /**
+     * @return string
+     */
+    public function getCurrency();
+
+    /**
+     * @param string $currency
+     * @return void
+     */
+    public function setCurrency($currency);
+
+    /**
+     * @return string
+     */
+    public function getMethod();
+
+    /**
+     * @param string $method
+     * @return void
+     */
+    public function setMethod($method);
+
+    /**
+     * @return string
+     */
+    public function getIdentifier();
+
+    /**
+     * @param string $identifier
+     * @return void
+     */
+    public function setIdentifier($identifier);
+
+    /**
+     * @return string
+     */
+    public function getCreatedAt();
+
+    /**
+     * @param string $createdAt
+     * @return mixed
+     */
+    public function setCreatedAt($createdAt);
+
+    /**
+     * @return string
+     */
+    public function getExpiredAt();
+
+    /**
+     * @param string $expiredAt
+     * @return mixed
+     */
+    public function setExpiredAt($expiredAt);
+
+    /**
+     * @return string
+     */
+    public function getClosedAt();
+
+    /**
+     * @param string $closedAt
+     * @return mixed
+     */
+    public function setClosedAt($closedAt);
+}

--- a/Api/Data/ContractSearchResultInterface.php
+++ b/Api/Data/ContractSearchResultInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Reach\Payment\Api\Data;
+
+use Magento\Framework\Api\SearchResultsInterface;
+
+interface ContractSearchResultInterface extends SearchResultsInterface
+{
+    /**
+     * @return ContractInterface[]
+     */
+    public function getItems();
+
+    /**
+     * @param ContractInterface[] $items
+     * @return void
+     */
+    public function setItems(array $items);
+}

--- a/Model/Contract.php
+++ b/Model/Contract.php
@@ -2,10 +2,19 @@
 
 namespace Reach\Payment\Model;
 
-use Reach\Payment\Helper\Data as ReachHelper;
+use Reach\Payment\Api\Data\ContractInterface;
 
-class Contract extends \Magento\Framework\Model\AbstractModel
+class Contract extends \Magento\Framework\Model\AbstractModel implements ContractInterface
 {
+    const CONTRACT_ID = 'contract_id';
+    const CUSTOMER_ID = 'customer_id';
+    const REACH_CONTRACT_ID = 'reach_contract_id';
+    const CURRENCY = 'currency';
+    const METHOD = 'method';
+    const IDENTIFIER = 'identifier';
+    const CREATED_AT = 'created_at';
+    const EXPIRED_AT = 'expired_at';
+    const CLOSED_AT = 'closed_at';
 
     /**
      * Constructor
@@ -24,6 +33,99 @@ class Contract extends \Magento\Framework\Model\AbstractModel
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $collection, $data);
+    }
+
+    /**
+     * @inheirtDoc
+     */
+    public function getContractId()
+    {
+        return $this->_getData(self::CONTRACT_ID);
+    }
+
+    public function setContractId($contractId)
+    {
+        $this->setData(self::CONTRACT_ID, $contractId);
+    }
+
+    public function getCustomerId()
+    {
+        return $this->_getData(self::CUSTOMER_ID);
+    }
+
+    public function setCustomerId($customerId)
+    {
+        $this->setData(self::CUSTOMER_ID, $customerId);
+    }
+
+    public function getReachContractId()
+    {
+        return $this->_getData(self::REACH_CONTRACT_ID);
+    }
+
+    public function setReachContractId($contractId)
+    {
+        $this->setData(self::REACH_CONTRACT_ID, $contractId);
+    }
+
+    public function getCurrency()
+    {
+        return $this->_getData(self::CURRENCY);
+    }
+
+    public function setCurrency($currency)
+    {
+        $this->setData(self::CURRENCY, $currency);
+    }
+
+    public function getMethod()
+    {
+        return $this->_getData(self::METHOD);
+    }
+
+    public function setMethod($method)
+    {
+        $this->setData(self::METHOD, $method);
+    }
+
+    public function getIdentifier()
+    {
+        return $this->_getData(self::IDENTIFIER);
+    }
+
+    public function setIdentifier($identifier)
+    {
+        $this->setData(self::IDENTIFIER, $identifier);
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->_getData(self::CREATED_AT);
+    }
+
+    public function setCreatedAt($createdAt)
+    {
+        $this->setData(self::CREATED_AT, $createdAt);
+    }
+
+    public function getExpiredAt()
+    {
+        return $this->_getData(self::EXPIRED_AT);
+    }
+
+    public function setExpiredAt($expiredAt)
+    {
+        $this->setData(self::EXPIRED_AT, $expiredAt);
+    }
+
+    public function getClosedAt()
+    {
+        return $this->_getData(self::CLOSED_AT);
+    }
+
+    public function setClosedAt($closedAt)
+    {
+        $this->setData(self::CLOSED_AT, $closedAt);
     }
 
     /**

--- a/Model/ContractRepository.php
+++ b/Model/ContractRepository.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Reach\Payment\Model;
+
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\LocalizedException;
+use Reach\Payment\Api\Data\ContractInterface;
+use Reach\Payment\Api\Data\ContractSearchResultInterface;
+use Reach\Payment\Api\Data\ContractSearchResultInterfaceFactory;
+use Reach\Payment\Api\ContractRepositoryInterface;
+use Reach\Payment\Model\ContractFactory;
+use Reach\Payment\Model\ResourceModel\Contract;
+use Reach\Payment\Model\ResourceModel\Contract\CollectionFactory;
+
+class ContractRepository implements ContractRepositoryInterface
+{
+    /**
+     * @var ContractFactory
+     */
+    private $contractFactory;
+
+    /**
+     * @var Contract
+     */
+    private $contractResource;
+
+    /**
+     * @var CollectionFactory
+     */
+    private $contractCollectionFactory;
+
+    /**
+     * @var ContractSearchResultInterfaceFactory
+     */
+    private $searchResultFactory;
+
+    /**
+     * @var CollectionProcessorInterface
+     */
+    private $collectionProcessor;
+
+    public function __construct(
+        ContractFactory $contractFactory,
+        Contract $contractResource,
+        CollectionFactory $contractCollectionFactory,
+        ContractSearchResultInterfaceFactory $contractSearchInterfaceFactory,
+        CollectionProcessorInterface $collectionProcessor
+    ) {
+        $this->contractFactory = $contractFactory;
+        $this->contractResource = $contractResource;
+        $this->contractCollectionFactory = $contractCollectionFactory;
+        $this->searchResultFactory = $contractSearchInterfaceFactory;
+        $this->collectionProcessor = $collectionProcessor;
+    }
+
+    /**
+     * @param int $id
+     * @return ContractInterface
+     * @throws NoSuchEntityException
+     */
+    public function getById($id)
+    {
+        $contract = $this->contractFactory->create();
+        $this->contractResource->load($contract, $id, 'reach_contract_id');
+        if (!$contract->getId()) {
+            throw new NoSuchEntityException(__('Unable to find Reach contract with ID "%1"', $id));
+        }
+        return $contract;
+    }
+
+    /**
+     * @param ContractInterface $contract
+     * @return ContractInterface
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     */
+    public function save(ContractInterface $contract)
+    {
+        $this->contractResource->save($contract);
+        return $contract;
+    }
+
+    /**
+     * @param ContractInterface $contract
+     * @return bool
+     * @throws CouldNotDeleteException
+     */
+    public function delete(ContractInterface $contract)
+    {
+        try {
+            $this->contractResource->delete($contract);
+        } catch (\Exception $exception) {
+            throw new CouldNotDeleteException(
+                __('Could not delete the entry: %1', $exception->getMessage())
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return ContractSearchResultInterface
+     * @throws LocalizedException
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria)
+    {
+        $collection = $this->contractCollectionFactory->create();
+        $this->collectionProcessor->process($searchCriteria, $collection);
+        $searchResults = $this->searchResultFactory->create();
+
+        $searchResults->setSearchCriteria($searchCriteria);
+        $searchResults->setItems($collection->getItems());
+
+        return $searchResults;
+    }
+}

--- a/Model/ContractSearchResult.php
+++ b/Model/ContractSearchResult.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Reach\Payment\Model;
+
+use Magento\Framework\Api\SearchResults;
+use Reach\Payment\Api\Data\ContractSearchResultInterface;
+
+class ContractSearchResult extends SearchResults implements ContractSearchResultInterface
+{
+
+}

--- a/Observer/ClosedContractObserver.php
+++ b/Observer/ClosedContractObserver.php
@@ -1,0 +1,167 @@
+<?php
+namespace Reach\Payment\Observer;
+
+use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\Event\ObserverInterface;
+use Psr\Log\LoggerInterface;
+use Reach\Payment\Api\ContractRepositoryInterface;
+
+class ClosedContractObserver implements ObserverInterface
+{
+    /**
+     * @var \Reach\Payment\Helper\Data
+     */
+    protected $reachHelper;
+
+    /**
+     * @var \Reach\Payment\Model\Api\HttpTextFactory
+     */
+    private $httpTextFactory;
+
+
+    /** @var LoggerInterface */
+    private $_logger;
+
+    /** @var ContractRepositoryInterface $contractRepository */
+    private $contractRepository;
+
+    /**
+     * @param \Reach\Payment\Helper\Data $reachHelper
+     * @param \Reach\Payment\Model\Api\HttpTextFactory $httpTextFactory
+     * @param \Magento\Framework\Model\Context $context
+     * @param ContractRepositoryInterface $contractRepository
+     */
+    public function __construct(
+        \Reach\Payment\Helper\Data $reachHelper,
+        \Reach\Payment\Model\Api\HttpTextFactory $httpTextFactory,
+        \Magento\Framework\Model\Context $context,
+        ContractRepositoryInterface $contractRepository)
+    {
+        $this->reachHelper = $reachHelper;
+        $this->httpTextFactory = $httpTextFactory;
+        $this->_logger = $context->getLogger();
+        $this->contractRepository = $contractRepository;
+    }
+
+    /**
+     * Set payment fee to order
+     *
+     * @param EventObserver $observer
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        $expiredContractId = $observer->getData('closed_contract_id');
+
+        $contract = $this->contractRepository->getById($expiredContractId);
+
+        // Only attempt to set the closed at if it's not already set
+        if (is_null($contract->getClosedAt())) {
+            $detail = $this->fetchContractDetail($expiredContractId);
+            $contract->setClosedAt($detail['closed_at']);
+            $this->contractRepository->save($contract);
+        }
+    }
+
+    /**
+     * TODO:: Move this method into some kind of helper class since it's essentially
+     *  a duplicate of the fetchContractDetail in SalesOrderPlaceAfterObserver
+     *
+     * Fetch contract detail
+     *
+     * @param string $contractId
+     * @return array|null
+     */
+    protected function fetchContractDetail($contractId)
+    {
+        $request=[];
+        $request['ContractId'] = $contractId;
+        $request['MerchantId'] = $this->reachHelper->getMerchantId();
+        $url = $this->reachHelper->getQueryUrl();
+        $response = $this->callCurl($url, $request);
+
+        if (isset($response['response']) && isset($response['signature'])) {
+
+            if ($this->validateResponse($response['response'], $response['signature'])) {
+                $response_extracted = json_decode($response['response'], true);
+
+                if ($response_extracted  && isset($response_extracted['Payment'])) {
+                    $detail=[];
+                    $detail['currency']= $response_extracted['ConsumerCurrency'];
+                    $detail['method']=$response_extracted['Payment']['Method'];
+                    $detail['identifier']=$response_extracted['Payment']['AccountIdentifier'];
+
+                    if (isset($response_extracted['Times']['Expiry'])) {
+                        $expiresAt = explode('T',$response_extracted['Times']['Expiry']);
+                        $detail['expire_at']= $expiresAt[0];
+                        $time = explode('.', $expiresAt[1]);
+                        $detail['expire_at'] .= ' '. $time[0];
+                    }
+
+                    if (isset($response_extracted['Times']['Closed'])) {
+                        $expiresAt = explode('T',$response_extracted['Times']['Closed']);
+                        $detail['closed_at']= $expiresAt[0];
+                        $time = explode('.', $expiresAt[1]);
+                        $detail['closed_at'] .= ' '. $time[0];
+                    }
+                    return $detail;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * TODO:: Move this method into some kind of helper class since this method
+     *  is duplicated in several classes.
+     * validate response
+     *
+     * @param array $response
+     * @param string $nonce
+     * @return boolean
+     */
+    protected function validateResponse($response, $nonce)
+    {
+        $nonce = str_replace(' ', '+', $nonce);
+        $key = $this->reachHelper->getSecret();
+        $signature =  base64_encode(hash_hmac('sha256', $response, $key, true));
+        return $signature == $nonce;
+    }
+
+    /**
+     * TODO:: Move this method into some kind of helper class since this method
+     *  is duplicated in several classes.
+     * Execute API request
+     *
+     * @param string $url
+     * @param array $params
+     * @param string $method
+     * @return return string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    protected function callCurl($url, $params, $method = "POST")
+    {
+        // Enable lines with logger function to turn on logging for debugging.
+        // $this->_logger->debug('---------------- callCurl - START OF REQUEST----------------');
+
+        $json = json_encode($params);
+        // $this->_logger->debug('$params: ');
+        // $this->_logger->debug(json_encode($params));
+        $secret = $this->reachHelper->getSecret();
+        // $this->_logger->debug('$secret: ');
+        // $this->_logger->debug(json_encode($secret));
+        $signature = base64_encode(hash_hmac('sha256', $json, $secret, true));
+        // $this->_logger->debug('$signature: ');
+        // $this->_logger->debug(json_encode($signature));
+        $rest = $this->httpTextFactory->create();
+        $rest->setContentType("application/x-www-form-urlencoded");
+        $rest->setUrl($url);
+        // $this->_logger->debug('$url: ');
+        // $this->_logger->debug(json_encode($url));
+        $result = $rest->executePost('request='.urlencode($json).'&signature='.urlencode($signature));
+        $responseString = $result->getResponseData();
+        $response =[];
+        parse_str($responseString, $response);
+        // $this->_logger->debug('---------------- callCurl - END OF REQUEST----------------');
+        return $response;
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -45,278 +45,275 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $installer->getConnection()->createTable($tableCurrencyPrecision);
         }
 
-        if (version_compare($context->getVersion(), '1.0.1') < 0) {
-            $quoteAddressTable = 'quote_address';
-            $quoteTable = 'quote';
-            $orderTable = 'sales_order';
-            $invoiceTable = 'sales_invoice';
-            $creditmemoTable = 'sales_creditmemo';
+        $quoteAddressTable = 'quote_address';
+        $quoteTable = 'quote';
+        $orderTable = 'sales_order';
+        $invoiceTable = 'sales_invoice';
+        $creditmemoTable = 'sales_creditmemo';
 
-            //Setup two columns for quote, quote_address and order
-            //Quote address tables
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($quoteAddressTable),
-                'reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Tax & Duty'
-                ]
-            );
-        
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($quoteAddressTable),
-                'base_reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Base Tax & Duty'
-                ]
-            );
+        //Setup two columns for quote, quote_address and order
+        //Quote address tables
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($quoteAddressTable),
+            'reach_duty',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length'=>'12,4',
+                'default' => 0.00,
+                'nullable' => true,
+                'comment' =>'Tax & Duty'
+            ]
+        );
 
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($quoteAddressTable),
-                'dhl_quote_id',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    255,
-                    'nullable' => true,
-                    'comment' =>'DHL Quote Id'
-                ]
-            );
-        
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($quoteAddressTable),
-                'dhl_breakdown',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    null,
-                    'nullable' => true,
-                    'comment' =>'DHL Breakdown'
-                ]
-            );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($quoteAddressTable),
+            'base_reach_duty',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length'=>'12,4',
+                'default' => 0.00,
+                'nullable' => true,
+                'comment' =>'Base Tax & Duty'
+            ]
+        );
 
-            //Quote tables
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($quoteTable),
-                'reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Tax & Duty'
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($quoteAddressTable),
+            'dhl_quote_id',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                255,
+                'nullable' => true,
+                'comment' =>'DHL Quote Id'
+            ]
+        );
 
-                ]
-            );
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($quoteTable),
-                'base_reach_duty',
-                [
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($quoteAddressTable),
+            'dhl_breakdown',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                null,
+                'nullable' => true,
+                'comment' =>'DHL Breakdown'
+            ]
+        );
+
+        //Quote tables
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($quoteTable),
+            'reach_duty',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length'=>'12,4',
+                'default' => 0.00,
+                'nullable' => true,
+                'comment' =>'Tax & Duty'
+
+            ]
+        );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($quoteTable),
+            'base_reach_duty',
+            [
+            'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+            'length'=>'12,4',
+            'default' => 0.00,
+            'nullable' => true,
+            'comment' =>'Base Tax & Duty'
+
+            ]
+        );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($quoteTable),
+            'dhl_quote_id',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                255,
+                'nullable' => true,
+                'comment' =>'DHL Quote Id'
+            ]
+        );
+
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($quoteTable),
+            'dhl_breakdown',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                null,
+                'nullable' => true,
+                'comment' =>'DHL Breakdown'
+            ]
+        );
+
+        //Order tables
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($orderTable),
+            'reach_duty',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length'=>'12,4',
+                'default' => 0.00,
+                'nullable' => true,
+                'comment' =>'Tax & Duty'
+
+            ]
+        );
+
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($orderTable),
+            'base_reach_duty',
+            [
                 'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
                 'length'=>'12,4',
                 'default' => 0.00,
                 'nullable' => true,
                 'comment' =>'Base Tax & Duty'
 
-                ]
-            );
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($quoteTable),
-                'dhl_quote_id',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    255,
-                    'nullable' => true,
-                    'comment' =>'DHL Quote Id'
-                ]
-            );
+            ]
+        );
 
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($quoteTable),
-                'dhl_breakdown',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    null,
-                    'nullable' => true,
-                    'comment' =>'DHL Breakdown'
-                ]
-            );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($orderTable),
+            'dhl_quote_id',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                255,
+                'nullable' => true,
+                'comment' =>'DHL Quote Id'
+            ]
+        );
 
-            //Order tables
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($orderTable),
-                'reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Tax & Duty'
-
-                ]
-            );
-
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($orderTable),
-                'base_reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Base Tax & Duty'
-
-                ]
-            );
-
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($orderTable),
-                'dhl_quote_id',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    255,
-                    'nullable' => true,
-                    'comment' =>'DHL Quote Id'
-                ]
-            );
-
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($orderTable),
-                'dhl_breakdown',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    null,
-                    'nullable' => true,
-                    'comment' =>'DHL Breakdown'
-                ]
-            );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($orderTable),
+            'dhl_breakdown',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                null,
+                'nullable' => true,
+                'comment' =>'DHL Breakdown'
+            ]
+        );
 
 
-            //Invoice tables
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($invoiceTable),
-                'reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Tax & Duty'
+        //Invoice tables
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($invoiceTable),
+            'reach_duty',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length'=>'12,4',
+                'default' => 0.00,
+                'nullable' => true,
+                'comment' =>'Tax & Duty'
 
-                ]
-            );
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($invoiceTable),
-                'base_reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Tax & Duty'
+            ]
+        );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($invoiceTable),
+            'base_reach_duty',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length'=>'12,4',
+                'default' => 0.00,
+                'nullable' => true,
+                'comment' =>'Tax & Duty'
 
-                ]
-            );
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($invoiceTable),
-                'dhl_quote_id',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    255,
-                    'nullable' => true,
-                    'comment' =>'DHL Quote Id'
-                ]
-            );
+            ]
+        );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($invoiceTable),
+            'dhl_quote_id',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                255,
+                'nullable' => true,
+                'comment' =>'DHL Quote Id'
+            ]
+        );
 
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($invoiceTable),
-                'dhl_breakdown',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    null,
-                    'nullable' => true,
-                    'comment' =>'DHL Breakdown'
-                ]
-            );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($invoiceTable),
+            'dhl_breakdown',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                null,
+                'nullable' => true,
+                'comment' =>'DHL Breakdown'
+            ]
+        );
 
-            //Credit memo tables
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($creditmemoTable),
-                'reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Tax & Duty'
+        //Credit memo tables
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($creditmemoTable),
+            'reach_duty',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length'=>'12,4',
+                'default' => 0.00,
+                'nullable' => true,
+                'comment' =>'Tax & Duty'
 
-                ]
-            );
-       
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($creditmemoTable),
-                'base_reach_duty',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    'length'=>'12,4',
-                    'default' => 0.00,
-                    'nullable' => true,
-                    'comment' =>'Tax & Duty'
+            ]
+        );
 
-                ]
-            );
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($creditmemoTable),
+            'base_reach_duty',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
+                'length'=>'12,4',
+                'default' => 0.00,
+                'nullable' => true,
+                'comment' =>'Tax & Duty'
 
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($creditmemoTable),
-                'dhl_quote_id',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    255,
-                    'nullable' => true,
-                    'comment' =>'DHL Quote Id'
-                ]
-            );
-            
-            $setup->getConnection()
-            ->addColumn(
-                $setup->getTable($creditmemoTable),
-                'dhl_breakdown',
-                [
-                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                    null,
-                    'nullable' => true,
-                    'comment' =>'DHL Breakdown'
-                ]
-            );
-        }
-        
-        if (version_compare($context->getVersion(), "1.0.4") < 0) {
-            //DHL Country of Origin tables
-            $setup->getConnection()
+            ]
+        );
+
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($creditmemoTable),
+            'dhl_quote_id',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                255,
+                'nullable' => true,
+                'comment' =>'DHL Quote Id'
+            ]
+        );
+
+        $setup->getConnection()
+        ->addColumn(
+            $setup->getTable($creditmemoTable),
+            'dhl_breakdown',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                null,
+                'nullable' => true,
+                'comment' =>'DHL Breakdown'
+            ]
+        );
+
+        //DHL Country of Origin tables
+        $setup->getConnection()
             ->addColumn(
                 $setup->getTable('reach_hs_code'),
                 'country_of_origin',
@@ -327,6 +324,19 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' =>'Country of Origin'
                 ]
             );
+
+        if (version_compare($context->getVersion(), "0.1.4") < 0) {
+            //DHL Country of Origin tables
+            $setup->getConnection()
+                ->addColumn(
+                    $setup->getTable('reach_open_contract'),
+                    'closed_at',
+                    [
+                        'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+                        'nullable' => true,
+                        'comment' => 'Closed at timestamp'
+                    ]
+                );
         }
 
          $installer->endSetup();

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -20,6 +20,10 @@
     <preference for="Reach\Payment\Api\Data\HttpResponseInterface" type="Reach\Payment\Model\Api\Data\HttpResponse" />
     <preference for="Reach\Payment\Api\Data\NotificationResponseInterface" type="Reach\Payment\Model\Api\Data\NotificationResponse" />
 
+    <preference for="Reach\Payment\Api\Data\ContractInterface" type="Reach\Payment\Model\Contract" />
+    <preference for="Reach\Payment\Api\Data\ContractSearchResultInterface" type="Reach\Payment\Model\ContractSearchResult" />
+    <preference for="Reach\Payment\Api\ContractRepositoryInterface" type="Reach\Payment\Model\ContractRepository" />
+
     <type name="Magento\Framework\Webapi\Rest\Request\DeserializerFactory">
         <arguments>
             <argument name="deserializers" xsi:type="array">

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -16,4 +16,8 @@
     <event name="checkout_submit_all_after">
         <observer name="reach_opencontract_sales_order_save_commit_after_observer" instance="Reach\Payment\Observer\SalesOrderPlaceAfterObserver" />
     </event>
+
+    <event name="reach_contract_closed">
+        <observer name="reach_contract_closed_observer" instance="Reach\Payment\Observer\ClosedContractObserver"/>
+    </event>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Reach_Payment" setup_version="2.3.9">
+    <module name="Reach_Payment" setup_version="0.1.3">
     	<sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
When a customer attempts to use a contract that is closed on Reach's
end, handling the ClosedContract response code will now update the row
in the database to set the closed at date.

These changes include:

- Specifically handling the ClosedContract error response code
- Dispatching a custom `reach_contract_closed` event and have the
observer class handle making the query request then update the row in
the database to set the closed at date
- Added respository classes to properly handle updating the Contract
entity